### PR TITLE
fix: Update docs import paths to use 'sas-lib'

### DIFF
--- a/docs/pages/instructions/change-authorized-signers.mdx
+++ b/docs/pages/instructions/change-authorized-signers.mdx
@@ -19,7 +19,7 @@ Returns a `TransactionBuilder` that can be used to build and send the transactio
 ## Example
 
 ```typescript
-import { getChangeAuthorizedSignersInstruction } from "solana-attestation-service";
+import { getChangeAuthorizedSignersInstruction } from "sas-lib";
 
 const transaction = getChangeAuthorizedSignersInstruction({
     payer: payerSigner,

--- a/docs/pages/instructions/change-schema-description.mdx
+++ b/docs/pages/instructions/change-schema-description.mdx
@@ -20,7 +20,7 @@ Returns a `TransactionBuilder` that can be used to build and send the transactio
 ## Example
 
 ```typescript
-import { getChangeSchemaDescriptionInstruction } from "solana-attestation-service";
+import { getChangeSchemaDescriptionInstruction } from "sas-lib";
 
 const transaction = getChangeSchemaDescriptionInstruction({
     payer: payerSigner,

--- a/docs/pages/instructions/change-schema-status.mdx
+++ b/docs/pages/instructions/change-schema-status.mdx
@@ -18,7 +18,7 @@ Returns a `TransactionBuilder` that can be used to build and send the transactio
 ## Example
 
 ```typescript
-import { getChangeSchemaStatusInstruction } from "solana-attestation-service";
+import { getChangeSchemaStatusInstruction } from "sas-lib";
 
 const transaction = getChangeSchemaStatusInstruction({
     authority: authoritySigner,

--- a/docs/pages/instructions/change-schema-version.mdx
+++ b/docs/pages/instructions/change-schema-version.mdx
@@ -22,7 +22,7 @@ Returns a `TransactionBuilder` that can be used to build and send the transactio
 ## Example
 
 ```typescript
-import { getChangeSchemaVersionInstruction } from "solana-attestation-service";
+import { getChangeSchemaVersionInstruction } from "sas-lib";
 
 const transaction = getChangeSchemaVersionInstruction({
     payer: payerSigner,

--- a/docs/pages/instructions/close-attestation.mdx
+++ b/docs/pages/instructions/close-attestation.mdx
@@ -21,7 +21,7 @@ Returns a `TransactionBuilder` that can be used to build and send the transactio
 ## Example
 
 ```typescript
-import { getCloseAttestationInstruction } from "solana-attestation-service";
+import { getCloseAttestationInstruction } from "sas-lib";
 
 const transaction = getCloseAttestationInstruction({
     payer: payerSigner,

--- a/docs/pages/instructions/close-tokenized-attestation.mdx
+++ b/docs/pages/instructions/close-tokenized-attestation.mdx
@@ -25,7 +25,7 @@ Returns a `TransactionBuilder` that can be used to build and send the transactio
 ## Example
 
 ```typescript
-import { getCloseTokenizedAttestationInstruction } from "solana-attestation-service";
+import { getCloseTokenizedAttestationInstruction } from "sas-lib";
 
 const transaction = getCloseTokenizedAttestationInstruction({
     payer: payerSigner,

--- a/docs/pages/instructions/create-attestation.mdx
+++ b/docs/pages/instructions/create-attestation.mdx
@@ -23,7 +23,7 @@ Returns a `TransactionBuilder` that can be used to build and send the transactio
 ## Example
 
 ```typescript
-import { getCreateAttestationInstruction } from "solana-attestation-service";
+import { getCreateAttestationInstruction } from "sas-lib";
 
 const transaction = getCreateAttestationInstruction({
     payer: payerSigner,

--- a/docs/pages/instructions/create-credential.mdx
+++ b/docs/pages/instructions/create-credential.mdx
@@ -20,7 +20,7 @@ Returns a `TransactionBuilder` that can be used to build and send the transactio
 ## Example
 
 ```typescript
-import { getCreateCredentialInstruction } from "solana-attestation-service";
+import { getCreateCredentialInstruction } from "sas-lib";
 
 const transaction = getCreateCredentialInstruction({
     payer: payerSigner,

--- a/docs/pages/instructions/create-schema.mdx
+++ b/docs/pages/instructions/create-schema.mdx
@@ -23,7 +23,7 @@ Returns a `TransactionBuilder` that can be used to build and send the transactio
 ## Example
 
 ```typescript
-import { getCreateSchemaInstruction } from "solana-attestation-service";
+import { getCreateSchemaInstruction } from "sas-lib";
 
 const transaction = getCreateSchemaInstruction({
     payer: payerSigner,

--- a/docs/pages/instructions/create-tokenized-attestation.mdx
+++ b/docs/pages/instructions/create-tokenized-attestation.mdx
@@ -34,7 +34,7 @@ Returns a `TransactionBuilder` that can be used to build and send the transactio
 ## Example
 
 ```typescript
-import { getCreateTokenizedAttestationInstruction } from "solana-attestation-service";
+import { getCreateTokenizedAttestationInstruction } from "sas-lib";
 
 const transaction = getCreateTokenizedAttestationInstruction({
     payer: payerSigner,

--- a/docs/pages/instructions/emit-event.mdx
+++ b/docs/pages/instructions/emit-event.mdx
@@ -16,7 +16,7 @@ Returns a `TransactionBuilder` that can be used to build and send the transactio
 ## Example
 
 ```typescript
-import { getEmitEventInstruction } from "solana-attestation-service";
+import { getEmitEventInstruction } from "sas-lib";
 
 const transaction = getEmitEventInstruction({
     eventAuthority: eventAuthoritySigner,


### PR DESCRIPTION
Replaces all occurrences of 'solana-attestation-service' with 'sas-lib' in TypeScript examples across instruction documentation pages to reflect the current package name.