### PR TITLE
add: SAS Workflow Guides (TypeScript) 

### DIFF
--- a/docs/pages/guides/creating-a-credential.mdx
+++ b/docs/pages/guides/creating-a-credential.mdx
@@ -1,1 +1,0 @@
-# Creating a Credential

--- a/docs/pages/guides/creating-a-schema.mdx
+++ b/docs/pages/guides/creating-a-schema.mdx
@@ -1,1 +1,0 @@
-# Creating a Schema

--- a/docs/pages/guides/creating-an-attestation.mdx
+++ b/docs/pages/guides/creating-an-attestation.mdx
@@ -1,1 +1,0 @@
-# Creating an Attestation

--- a/docs/pages/guides/parsing-an-attestation.mdx
+++ b/docs/pages/guides/parsing-an-attestation.mdx
@@ -1,1 +1,0 @@
-# Parsing an Attestation

--- a/docs/pages/guides/ts/how-to-create-digital-credentials.mdx
+++ b/docs/pages/guides/ts/how-to-create-digital-credentials.mdx
@@ -110,7 +110,7 @@ Each of these components is represented on-chain as an account governed by the S
 
 ## Project Setup
 
-*Prefer to jump straight to the code? Check out our [Examples Repo on GitHub](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript) for the complete code for this guide\!*
+*Prefer to jump straight to the code? Check out our [Examples Repo on GitHub](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript/attestation-flow-guides/src/attestation-demo.ts) for the complete code for this guide\!*
 
 Let's start by creating our project structure:
 
@@ -203,6 +203,7 @@ import {
     deriveCredentialPda,
     deriveSchemaPda,
     deriveEventAuthorityAddress,
+    getCloseAttestationInstruction,
     SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS
 } from "sas-lib";
 import {
@@ -688,5 +689,5 @@ The Solana Attestation Service provides a powerful foundation for building trust
 
 - Need help? Ask questions the [Solana Stack Exchange](https://solana.stackexchange.com/) with a `SAS` tag.
 - [**SAS Source Code**](https://github.com/solana-foundation/solana-attestation-service)  
-- [**Complete Code Example**](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript)  
+- [**Complete Code Example**](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript/attestation-flow-guides/src/attestation-demo.ts)  
 - [**Solana Developer Resources**](https://solana.com/developers)

--- a/docs/pages/guides/ts/how-to-create-digital-credentials.mdx
+++ b/docs/pages/guides/ts/how-to-create-digital-credentials.mdx
@@ -1,0 +1,692 @@
+---
+title: How to Build Digital Credentials using Solana Attestation Service
+description: This getting started guide teaches you the basics of the Solana Attestation Service and how to build with it using TypeScript.
+date: 2025-06-27
+---
+
+# How to Build Digital Credentials using Solana Attestation Service (TypeScript)
+
+## What is Solana Attestation Service?
+
+The Solana Attestation Service (SAS) is a powerful on-chain credentialing system that enables developers to create, manage, and verify digital attestations on the Solana blockchain. Think of it as a decentralized way to issue and verify credentials, certificates, badges, or any form of digital proof that someone or something meets certain criteria. 
+
+SAS introduces powerful capabilities for associating offchain data with on-chain accounts, building trust and identity systems, including:
+
+* **Compliance Systems** \- Provable KYC/AML status
+* **Professional Credentials** \- Verification of professional certificates or degrees  
+* **Gaming Achievements** \- Issuance of badges/milestone recognition  
+* **Event Attendance** \- Proof of participation  
+* **Loyalty** \- Rewards users for engagement, volume, etc.
+
+Attestations can then be consumed by service providers (e.g., DEXs, DAOs, or other platforms) to vet users and gate services based on their credentials (e.g., enable VIP Members to access unique content on a website or Accredited Investors to participate in certain on-chain investment opportunities).
+
+This guide will walk you through creating a complete attestation script that:
+
+* Creates a new credential with authorized signers  
+* Defines a schema for the type of data we want to attest  
+* Issues an attestation to a specific user  
+* Updates authorized signers for enhanced security  
+* Verifies attestations for both attested and non-attested users
+* Closes an attestation (effectively revoking a user's credential)
+
+The end goal will be to see a working attestation system in action:
+
+```shell
+Starting Solana Attestation Service Demo
+
+1. Setting up wallets and funding payer...
+    - Airdrop completed: 384wkVUZsyuk53Npyy5N29tWTRA6dGe82b6fpBa4gKMDHoZYsb3iNAUfYMD6Lo2V3MYJeDhk8xvEDrmyxjeW2xdB
+
+2. Creating Credential...
+    - Credential created - Signature: 5LnkP762S9yvcLxFUVU7N3Mzen5Tqp8abC4h1rJYZn1vCviq7GpyFvUNVneVd8btiV7KK6pe5NEpXvwtTXK96gM1
+    - Credential PDA: 3yB9Xrgg73oWxuQv8564q9LwwRL2rX2fjZD7ssy3X4M3
+
+3.  Creating Schema...
+    - Schema created - Signature: 4qHfY6FfjsUrssymRDWgShgr2sxRgWTbSdHxnJhgus7Cra5t6n6f4snhPDDkMyAX9bkqpD7aMCbKUpoJnD9NXzoS
+    - Schema PDA: FfNqeLfPHy4p7FPgH2LDTm9gzVWSDcupA3LUhiMEzBXw
+
+4. Creating Attestation...
+    - Attestation created - Signature: 3czDWMmDkZEJbww7qfphcKe96vJJMAawFk2DedbknrzVpBSJ5fGBjtEK1aZHsYzvj8QLvRcadohEaxANNb4c4nUN
+    - Attestation PDA: 6JEEL89jNXvxk63N6ND8njsp6e1Ve8BLZYShYNfjFajR
+
+5. Updating Authorized Signers...
+    - Authorized signers updated - Signature: 23V3bmTYnKUA6fT9WnchFmKi7bNj9biqxxnLBW9coUtkWhippu49PrY5fnefAcHWKofNDoojCicD2qJFq16RNz1Y
+
+6. Verifying Attestations...
+    - Attestation data: { name: 'test-user', age: 100, country: 'usa' }
+    - Test User is verified
+    - Random User is not verified
+
+7. Closing Attestation...
+    - Closed attestation - Signature: 5DS7GYpzKirWcusEgBhN3LGfX7D34q5rSQmbdNpCmzU5nYM1CUA4fJ3B9DRXwuiYNHvMnbBRSiMGDVJoCfLMc6ti
+
+Solana Attestation Service demo completed successfully!
+```
+
+Let's get started!
+
+## Prerequisites
+
+Before starting this tutorial, ensure you have:
+
+* [**Node.js**](https://nodejs.org/en/download) (v22 or later)  
+* [**Solana CLI**](https://solana.com/docs/intro/installation) v 2.2.x or greater  
+* **Familiarity** with [Solana Program Derived Addresses (PDAs)](https://solana.com/docs/core/pda) and [on-chain accounts](https://solana.com/docs/core/accounts)
+* [TypeScript](http://typescriptlang.org/) Experience
+
+## Understanding Solana Attestation Service
+
+SAS provides a standardized way to create verifiable claims about entities (users, organizations, or even other programs) directly on Solana.
+
+### Core Concepts
+
+The attestation system consists of three main components:
+
+* **Credentials** - The top-level identity or organization that issues attestations. Think of this as a "university" that issues diplomas or the "company" that issues employee badges.  
+* **Schemas** - Define the structure and fields of data that can be attested. Schemas are essentially a template that specifies what information (name, age, skills, etc.) will be included in attestations.  
+* **Attestations** - Individual claims made about specific entities following a particular schema. These are the actual "diplomas" or "badges" issued to users.
+
+Each of these components is represented on-chain as an account governed by the SAS Program: [`22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG`](https://explorer.solana.com/address/22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG).
+
+
+
+### Key Features
+
+* **Authority Management** - Credentials can have multiple authorized signers who can issue attestations  
+* **Expiration Support** - Attestations can have expiration dates for time-sensitive credentials  
+* **Structured Data** - Schemas define typed data structures for consistent attestations  
+* **Versioning** - Schemas can be versioned for variations over time
+* **Pausable** - Schemas can be paused, or disabled
+* **Verification** - Anyone can verify if a user has a valid attestation for a specific credential
+* **Revocable** - Attestations can be terminated by authorized signers defined in the _Credential*
+
+### Key Considerations
+
+* **Data Privacy:** Because attestations are on-chain, the data can be read by anyone. Do not store personal identifiable or other sensitive information directly on chain. Consider what data to include directly vs. storing hashes of sensitive information off-chain.  
+* **Trusted Credentials** - anyone can create a credential/schema. Make sure you know/trust the credential provider if you are accepting an Attestation as verification of a user's credentials.
+* **User Verification** - ensure connected wallets are actual users by requiring signing a message (e.g., [Sign in with Solana](https://github.com/phantom/sign-in-with-solana) or [Supabase](https://supabase.com/docs/guides/auth/auth-web3#sign-in-with-solana))   
+* **Versioning** Note that *Schemas* are versioned, so you will need to establish business practices for monitoring and handling schema changes. This guide will walk you through using a single version–we will cover more advanced applications in a future guide.
+* **Performance:** Verification checks can be batched and cached. For certain use cases, consider indexing services for applications that need to check many attestations frequently.
+
+## Project Setup
+
+*Prefer to jump straight to the code? Check out our [Examples Repo on GitHub](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript) for the complete code for this guide\!*
+
+Let's start by creating our project structure:
+
+```shell
+mkdir solana-attestation-demo && cd solana-attestation-demo
+```
+
+Initialize a new Node.js project with the required dependencies
+
+
+:::code-group
+
+```bash [npm]
+npm init -y
+npm i sas-lib gill
+npm i --save-dev typescript ts-node @types/node
+```
+ 
+```bash [pnpm]
+pnpm init
+pnpm i sas-lib gill
+pnpm i -D typescript ts-node @types/node
+```
+ 
+```bash [yarn]
+yarn init -y
+yarn add sas-lib gill
+yarn add -D typescript ts-node @types/node
+```
+ 
+:::
+
+_Note: [Gill](https://gill.site/) extends the Solana Kit library with some helper functions that we will use in this demo._ 
+
+
+Create a `tsconfig.json` file:
+
+```json
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "nodenext",
+    "lib": ["es2020"],
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "rootDir": "./", 
+  "outDir": "./dist",
+  "include": ["./"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+Update your `package.json` scripts:
+
+```json
+"scripts": {
+  "start": "ts-node attestation-demo.ts",
+  "build": "tsc"
+}
+```
+
+
+## Implementation
+
+Let's create our `attestation-demo.ts` file and build it step by step:
+
+### Imports and Configuration
+
+Start with the necessary imports and configuration:
+
+```ts
+import {
+    getCreateCredentialInstruction,
+    getCreateSchemaInstruction,
+    serializeAttestationData,
+    getCreateAttestationInstruction,
+    fetchSchema,
+    getChangeAuthorizedSignersInstruction,
+    fetchAttestation,
+    deserializeAttestationData,
+    deriveAttestationPda,
+    deriveCredentialPda,
+    deriveSchemaPda,
+    deriveEventAuthorityAddress,
+    SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS
+} from "sas-lib";
+import {
+    airdropFactory,
+    generateKeyPairSigner,
+    lamports,
+    Signature,
+    TransactionSigner,
+    IInstruction,
+    Address,
+    Blockhash,
+    getComputeUnitEstimateForTransactionMessageFactory,
+    createSolanaClient,
+    createTransaction,
+    SolanaClient,
+} from "gill";
+
+const CONFIG = {
+    CLUSTER_OR_RPC: 'devnet',
+    CREDENTIAL_NAME: 'TEST-ORGANIZATION',
+    SCHEMA_NAME: 'THE-BASICS',
+    SCHEMA_LAYOUT: Buffer.from([12, 0, 12]),
+    SCHEMA_FIELDS: ["name", "age", "country"],
+    SCHEMA_VERSION: 1,
+    SCHEMA_DESCRIPTION: 'Basic user information schema for testing',
+    ATTESTATION_DATA: {
+        name: "test-user",
+        age: 100,
+        country: "usa",
+    },
+    ATTESTATION_EXPIRY_DAYS: 365
+};
+```
+
+This sets up our basic configuration, including:
+
+- **Connection details**: we'll be using our Solana `devnet` for this demo.
+    :::details[Testing on Localnet?]
+
+    If you prefer to use `localnet`, you will need to make sure to fetch the SAS program off mainnet by calling:
+    ```
+    solana program dump -u m 22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG sas.so
+    ```
+    and launching it with your test validator:
+
+    ```
+    solana-test-validator -r --bpf-program 22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG path/to/sas.so
+    ```
+    :::
+- **Credential parameters** (name and authorized signers)  
+- **Schema definition** (structure, fields, and description)  
+- **Attestation data** (the actual information we'll attest)
+
+#### Schemas and Layouts
+
+Before moving on, let's examine the Schema Layout and Fields we defined above. The `SCHEMA_LAYOUT` array defines the data types for each field in our attestation, where each number corresponds to a specific data type from the Solana Attestation Service's type system. In our example, `Buffer.from([12, 0, 12])` maps to our three fields: 
+- the first `12` represents a String type for the "name" field, 
+- `0` represents a U8 integer type for the "age" field, and 
+- the final `12` represents another String type for the "country" field. 
+
+The `SCHEMA_FIELDS` array provides human-readable names that correspond one-to-one with the layout types. This approach ensures that when attestations are created, the data is properly typed and validated according to the schema definition. The available data types range from basic integers (U8, U16, U32, U64, U128) and signed integers (I8-I128) to booleans, characters, strings, and even vectors of these types, giving you flexibility in designing your attestation data structures. Check out the full list of options and mapping [here](/schemas#schema-layout-data-types).
+
+### Utility Functions
+
+Next, let's add a couple of utility functions to handle keypair management and transaction confirmations:
+
+```ts
+async function setupWallets(client: SolanaClient) {
+    try {
+        const payer = await generateKeyPairSigner(); // or loadKeypairSignerFromFile(path.join(process.env.PAYER));
+        const authorizedSigner1 = await generateKeyPairSigner();
+        const authorizedSigner2 = await generateKeyPairSigner();
+        const issuer = await generateKeyPairSigner();
+        const testUser = await generateKeyPairSigner();
+
+        const airdrop = airdropFactory({ rpc: client.rpc, rpcSubscriptions: client.rpcSubscriptions });
+        const airdropTx: Signature = await airdrop({
+            commitment: 'processed',
+            lamports: lamports(BigInt(1_000_000_000)),
+            recipientAddress: payer.address
+        });
+
+        console.log(`    - Airdrop completed: ${airdropTx}`);
+        return { payer, authorizedSigner1, authorizedSigner2, issuer, testUser };
+    } catch (error) {
+        throw new Error(`Failed to setup wallets: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+}
+```
+
+Our `setupWallets` function creates five keypairs and airdrops SOL to our payer account:
+
+These utility functions handle:
+
+This should create five keypair files in the `wallets` directory: 
+
+- `payer` will be used to pay our transaction fees  
+- `issuer` will be the authority that creates our credential  
+- Two `authorizedSigner` keys will be authorized to create attestations  
+- `testUser` will receive the attestation we create
+
+Next add a reusable function that will help us easily create and send transactions. Add the following to your code: 
+
+```ts
+async function sendAndConfirmInstructions(
+    client: SolanaClient,
+    payer: TransactionSigner,
+    instructions: IInstruction[],
+    description: string
+): Promise<Signature> {
+    try {
+        const simulationTx = createTransaction({
+            version: "legacy",
+            feePayer: payer,
+            instructions: instructions,
+            latestBlockhash: {
+                blockhash: '11111111111111111111111111111111' as Blockhash,
+                lastValidBlockHeight: 0n,
+            },
+            computeUnitLimit: 1_400_000,
+            computeUnitPrice: 1,
+        });
+
+        const estimateCompute = getComputeUnitEstimateForTransactionMessageFactory({ rpc: client.rpc });
+        const computeUnitLimit = await estimateCompute(simulationTx);
+        const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
+        const tx = createTransaction({
+            version: "legacy",
+            feePayer: payer,
+            instructions: instructions,
+            latestBlockhash,
+            computeUnitLimit,
+            computeUnitPrice: 1, // In production, use dynamic pricing
+        });
+
+        const signature = await client.sendAndConfirmTransaction(tx);
+        console.log(`    - ${description} - Signature: ${signature}`);
+        return signature;
+    } catch (error) {
+        throw new Error(`Failed to ${description.toLowerCase()}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+}
+```
+Our function does two things: 
+1. First, we create a dummy transaction to simulate the total compute units required (more information on compute [here](https://solana.com/docs/core/fees#compute-budget)).
+2. Then we assemble our optimized transaction and send it to the network for processing.
+
+### Attestation Verification Function
+
+Now let's add a verification function that demonstrates how to check if a user has a valid attestation. To verify a user's attestation, we will need to pass two pieces of information: the user's address (or other identifier associated with the user) and the Schema address that you want to validate against. Add the `verifyAttestation` function to your code and then we will walk through how it works:
+
+```ts
+async function verifyAttestation({
+    client,
+    schemaPda,
+    userAddress
+}: {
+    client: SolanaClient;
+    schemaPda: Address;
+    userAddress: Address;
+}): Promise<boolean> {
+    try {
+        const schema = await fetchSchema(client.rpc, schemaPda);
+        if (schema.data.isPaused) {
+            console.log(`    -  Schema is paused`);
+            return false;
+        }
+        const [attestationPda] = await deriveAttestationPda({
+            credential: schema.data.credential,
+            schema: schemaPda,
+            nonce: userAddress
+        });
+        const attestation = await fetchAttestation(client.rpc, attestationPda);
+        const attestationData = deserializeAttestationData(schema.data, attestation.data.data as Uint8Array);
+        console.log(`    - Attestation data:`, attestationData);
+        const currentTimestamp = BigInt(Math.floor(Date.now() / 1000));
+        return currentTimestamp < attestation.data.expiry;
+    } catch (error) {
+        return false;
+    }
+}
+```
+
+This function:
+
+- **Fetches the Schema**: check to ensure the schema is active
+- **Derives the attestation PDA** for a specific user  
+- **Deserializes the data** to show what was attested  
+- **Validates the attestation** exists and hasn't expired  
+
+Additionally, if you know it, you could pass a `credentialPda` as a double check that your schema is correctly associated with the known credential.
+
+### Step 1: Setup
+
+Now, let's build the main demonstration function that showcases the complete attestation workflow. Add the `main` function to your code--we'll use this to outline for our steps:
+
+```ts
+async function main() {
+    console.log("Starting Solana Attestation Service Demo\n");
+    
+    const client: SolanaClient = createSolanaClient({ urlOrMoniker: CONFIG.CLUSTER_OR_RPC });
+
+    // Step 1: Setup wallets and fund payer
+    console.log("1. Setting up wallets and funding payer...");
+    const { payer, authorizedSigner1, authorizedSigner2, issuer, testUser } = await setupWallets(client);
+
+    // Step 2: Create Credential
+
+
+    // Step 3: Create Schema
+
+
+    // Step 4: Create Attestation
+
+
+    // Step 5: Update Authorized Signers
+
+
+    // Step 6: Verify Attestations
+
+
+    // Step 7. Close Attestation
+
+
+}
+
+main()
+    .then(() => console.log("\nSolana Attestation Service demo completed successfully!"))
+    .catch((error) => {
+        console.error("❌ Demo failed:", error);
+        process.exit(1);
+    });
+```
+
+The current code includes spaces for 7 steps. We've started by creating our client and calling our `setupWallets` function. Let's add the remaining steps next.
+
+### Step 2: Create Credential
+
+First, we will need to create our *Credential*. This establishes the issuing authority (like a certification body) with initial authorized signers.
+
+Add the following code to your `main` function:
+
+```ts
+    // Step 2: Create Credential
+    console.log("\n2. Creating Credential...");
+    const [credentialPda] = await deriveCredentialPda({
+        authority: issuer.address,
+        name: CONFIG.CREDENTIAL_NAME
+    });
+
+    const createCredentialInstruction = getCreateCredentialInstruction({
+        payer,
+        credential: credentialPda,
+        authority: issuer,
+        name: CONFIG.CREDENTIAL_NAME,
+        signers: [authorizedSigner1.address]
+    });
+
+    await sendAndConfirmInstructions(client, payer, [createCredentialInstruction], 'Credential created');
+    console.log(`    - Credential PDA: ${credentialPda}`);
+```
+
+Here, we just need to use a couple of helper function `sas-lib` package:
+- `deriveCredentialPda`: derives the PDA of our credential account based on the authority (our issuer wallet) and the name of our credential (meaning an issuer could create multiple credentials by creating new ones with different names) ([ref](https://attest.solana.com/docs/helpers#credential-pda)).
+-  `getCreateCredentialInstruction`: will assemble the instruction to create the credential account ([ref](https://attest.solana.com/docs/instructions/create-credential)). For now, we will just add a single authorized signer, so that we can add our second signer later. 
+
+We send our instruction to the network by calling our `sendAndConfirmInstructions` helper function.
+
+### Step 3: Create Schema
+
+Next, we need to define our *Schema* to define the structure of data that can be attested (name, age, country in our example). Add the following to your code:
+
+```ts
+    // Step 3: Create Schema
+    console.log("\n3.  Creating Schema...");
+    const [schemaPda] = await deriveSchemaPda({
+        credential: credentialPda,
+        name: CONFIG.SCHEMA_NAME,
+        version: CONFIG.SCHEMA_VERSION
+    });
+
+    const createSchemaInstruction = getCreateSchemaInstruction({
+        authority: issuer,
+        payer,
+        name: CONFIG.SCHEMA_NAME,
+        credential: credentialPda,
+        description: CONFIG.SCHEMA_DESCRIPTION,
+        fieldNames: CONFIG.SCHEMA_FIELDS,
+        schema: schemaPda,
+        layout: CONFIG.SCHEMA_LAYOUT,
+    });
+
+    await sendAndConfirmInstructions(client, payer, [createSchemaInstruction], 'Schema created');
+    console.log(`    - Schema PDA: ${schemaPda}`);
+```
+
+We follow a similar pattern here--derive PDA, assemble instruction, and send it to the network using `sendAndConfirmInstructions`:
+- `deriveSchemaPda`: derives the PDA of our schema account based on the credential we created in Step 2, the name of our schema, and the version ([ref](https://attest.solana.com/docs/helpers#schema-pda)).
+-  `getCreateSchemaInstruction`: will assemble the instruction to create the schema account ([ref](https://attest.solana.com/docs/instructions/create-schema)). 
+
+
+### Step 4: Create Attestation
+
+Next, we need to issue an actual attestation to a specific user with the defined data and expiration. Add the following to Step 4 of your `main` function:
+
+```ts
+    // Step 4: Create Attestation
+    console.log("\n4. Creating Attestation...");
+    const [attestationPda] = await deriveAttestationPda({
+        credential: credentialPda,
+        schema: schemaPda,
+        nonce: testUser.address
+    });
+
+    const schema = await fetchSchema(client.rpc, schemaPda);
+    const expiryTimestamp = Math.floor(Date.now() / 1000) + (CONFIG.ATTESTATION_EXPIRY_DAYS * 24 * 60 * 60);
+
+    const createAttestationInstruction = await getCreateAttestationInstruction({
+        payer,
+        authority: authorizedSigner1,
+        credential: credentialPda,
+        schema: schemaPda,
+        attestation: attestationPda,
+        nonce: testUser.address,
+        expiry: expiryTimestamp,
+        data: serializeAttestationData(schema.data, CONFIG.ATTESTATION_DATA),
+    });
+
+    await sendAndConfirmInstructions(client, payer, [createAttestationInstruction], 'Attestation created');
+    console.log(`    - Attestation PDA: ${attestationPda}`);
+```
+
+Like before, we will first derive our Attestation PDA using a helper function, `deriveAttestationPda` ([ref](https://attest.solana.com/docs/helpers#attestation-pda)). Note that the parameters include a `nonce` which can be a user's address or some other unique identifier address (e.g. some value stored off-chain).
+
+Prior to calling `getCreateAttestationInstruction`, we need to do a couple of things:
+- We must fetch our *Schema* from the chain--we will use `fetchSchema` to get the deserialized schema data which is required to serialize our attestation data. We do so by passing the schema data and our attestation into `serializeAttestationData`.
+- We define an expiration of 1-year from now.
+
+_Notice that the `authority` in our instruction parameters is `authorizedSigner1`, the authorized signer we defined in Step 2 when we created our credential._
+
+Finally, we send the instruction to the network to create the attestation PDA.
+
+### Step 5: Update Authorized Signers
+
+We mentioned earlier that we can update a credential's authorized signers. Let's add `authorizedSigner2` as an authorized signer to our credential to demonstrate how to manage who can issue attestations for the credential. Add the following to Step 5 of your `main` function:
+
+```ts
+    // Step 5: Update Authorized Signers
+    console.log("\n5. Updating Authorized Signers...");
+    const changeAuthSignersInstruction = await getChangeAuthorizedSignersInstruction({
+        payer,
+        authority: issuer,
+        credential: credentialPda,
+        signers: [authorizedSigner1.address, authorizedSigner2.address]
+    });
+
+    await sendAndConfirmInstructions(client, payer, [changeAuthSignersInstruction], 'Authorized signers updated');
+```
+
+We just need to assemble an instruction passing our new signers array (this replaces the old list of signers, so make sure to include existing signers you wish to keep) into `getChangeAuthorizedSignersInstruction` and send it to the network with our helper function. 
+
+### Step 6: Verify Attestations
+
+Let's run a verification check to show how you might check if users have valid attestations, testing both attested and non-attested users. Normally, you might run something like this on your backend when a user signs into your platform. Add the following to Step 6 of your `main` function: 
+
+```ts
+    // Step 6: Verify Attestations
+    console.log("\n6. Verifying Attestations...");
+
+    const isUserVerified = await verifyAttestation({
+        client,
+        schemaPda,
+        userAddress: testUser.address
+    });
+    console.log(`    - Test User is ${isUserVerified ? 'verified' : 'not verified'}`);
+
+    const randomUser = await generateKeyPairSigner();
+    const isRandomVerified = await verifyAttestation({
+        client,
+        schemaPda,
+        userAddress: randomUser.address
+    });
+    console.log(`    - Random User is ${isRandomVerified ? 'verified' : 'not verified'}`);
+```
+
+Here, we are calling our helper function `verifyAttestation` twice: once with our `testUser` address (which we would expect to be verified at this point) and a new `randomUser` who does not have an attestation (we would expect this user's verification to fail).
+
+### Step 7: Close Attestation
+
+Finally, let's revoke an attestation from a user. Add the following code to your project as Step 7: 
+
+```ts
+    // Step 7. Close Attestation
+    console.log("\n7. Closing Attestation...");
+
+    const eventAuthority = await deriveEventAuthorityAddress();
+    const closeAttestationInstruction = await getCloseAttestationInstruction({
+        payer,
+        attestation: attestationPda,
+        authority: authorizedSigner1,
+        credential: credentialPda,
+        eventAuthority,
+        attestationProgram: SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS
+    });
+    await sendAndConfirmInstructions(client, payer, [closeAttestationInstruction], 'Closed attestation');
+```
+
+In order to generate an attesation instruction, we need to get the Event Authority address using `deriveEventAuthorityAddress`. The event authority is used to emit close events in the SAS program. We then assemble our instruction using the `getCloseAttestationInstruction`--note that we must pass one of our `authorizedSigner` addresses into the `authority` parameter.
+
+## Run the Demonstration
+
+To test your attestation workflow, run the script in your project terminal:
+
+:::code-group
+ 
+```bash [npm]
+npm start
+```
+ 
+```bash [pnpm]
+pnpm start
+```
+ 
+```bash [yarn]
+yarn start
+```
+ 
+:::
+
+Here's what you should expect to see in the output:
+
+```
+Starting Solana Attestation Service Demo
+
+1. Setting up wallets and funding payer...
+    - Airdrop completed: 4QE4VGMxnvU9psgjDCYSoRsGEcdZzSsnqFKdzgTf5tPt2i833TC2gLdZE6QZfphie4S9MXNgJEVpQhvwgQJG5Bd5
+
+2. Creating Credential...
+    - Credential created - Signature: 2hb857yRrxficGU6zCMEvMwf6uKTASfgswgmwx1VS9z6zUL66FoapXMNK5VV7P3cZ6HktBMETp2Pu85EvSvUu1dr
+    - Credential PDA: 14Bfygrnpj7bA5H8gvAU3Jr1dfpudZFr2QkJSUFUqoYp
+
+3.  Creating Schema...
+    - Schema created - Signature: 3Jo9pQgPcAJj1AmYm6weR9t4tw4Unq2qTxjS5przBUbwt94TLGm1sDaV7z5pBzt1Kyw4oxuCYg6NkUBijVs6vJ4X
+    - Schema PDA: EyzsLnwtcCXrPJ8bSWHopRRNj3nGicXwuj8McfskToNs
+
+4. Creating Attestation...
+    - Attestation created - Signature: 2UJAcwTEF98xge1HPfZicYiBW4NqQDrtBiLcvAWWJ9sx9x4XyYZD4XGuwfkero11Mw5X9fhFzb7QTAMGvewDyZek
+    - Attestation PDA: B2CQ5uqsHgV9QYcCdqfeZGEWNJijTTFgNutNVcFjae8D
+
+5. Updating Authorized Signers...
+    - Authorized signers updated - Signature: 3h7x8y8v5fGyV368b6DxDuJ6HpD73whAGVYNJLmTQPk3HezgZcWqsMXPcHqiYM9NQzwHJgCQmhyqnteE1yHVrDDu
+
+6. Verifying Attestations...
+    - Attestation data: { name: 'test-user', age: 100, country: 'usa' }
+    - Test User is verified
+    - Random User is not verified
+
+7. Closing Attestation...
+    - Closed attestation - Signature: 5DS7GYpzKirWcusEgBhN3LGfX7D34q5rSQmbdNpCmzU5nYM1CUA4fJ3B9DRXwuiYNHvMnbBRSiMGDVJoCfLMc6ti
+
+Solana Attestation Service demo completed successfully!
+```
+
+Nice job! 
+
+## Wrap Up
+
+Congratulations! You've successfully implemented a complete Solana Attestation Service system. You now have a working demonstration that shows how to:
+
+- **Create credentials** that represent issuing authorities  
+- **Define schemas** for structured attestation data  
+- **Issue attestations** to specific users  
+- **Manage authorized signers** for enhanced security
+- **Verify attestations** programmatically  
+- **Close attestation** as needed
+
+The Solana Attestation Service provides a powerful foundation for building trust and identity systems on Solana. Whether you're creating compliance systems, financial credentials, professional certifications, or gaming achievements, SAS gives you the tools to issue and verify claims in a decentralized, transparent way.
+
+**Want to learn more?** Check out our [Guide: How to Create Tokenized Credentials using Solana Attestation Service](/guides/ts/tokenized-attestations).
+
+
+## Additional Resources
+
+- Need help? Ask questions the [Solana Stack Exchange](https://solana.stackexchange.com/) with a `SAS` tag.
+- [**SAS Source Code**](https://github.com/solana-foundation/solana-attestation-service)  
+- [**Complete Code Example**](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript)  
+- [**Solana Developer Resources**](https://solana.com/developers)

--- a/docs/pages/guides/ts/tokenized-attestations.mdx
+++ b/docs/pages/guides/ts/tokenized-attestations.mdx
@@ -1,0 +1,754 @@
+---
+title: How to Create Tokenized Credentials using Solana Attestation Service
+description: This implementation guide teaches you the basics of the Solana Attestation Service and how to build with it using TypeScript.
+date: 2025-06-27
+---
+
+# How to Create Tokenized Credentials using Solana Attestation Service (TypeScript)
+
+## What are Tokenized Credentials?
+
+In our [previous guide](/guides/ts/how-to-create-digital-credentials), we explored the basics of the Solana Attestation Service (SAS) and learned how to create credentials, schemas, and attestations. Now we'll take this a step further by creating **tokenized credentials** - attestations that are represented as SPL tokens using Solana's Token-2022 program.
+
+Tokenized credentials offer several advantages over standard attestations:
+
+* **Wallet Integration** - Seamless display in existing Solana wallets, making credentials more visible to users
+* **Standardized Interface** - Leverage existing token infrastructure and tooling (e.g., [DAS API](https://developers.metaplex.com/das-api))
+
+This guide will walk you through creating, verifying, and closing tokenized attestations.
+
+## Prerequisites
+
+Before starting this tutorial, ensure you have:
+
+* Basic understanding of Solana Attestation Service ([Guide: How to Build Digital Credentials using Solana Attestation Service](/guides/ts/how-to-create-digital-credentials))
+* Basic understanding of [Token 2022](https://spl.solana.com/token-2022)
+* **Node.js** (v22 or later)  
+* **Solana CLI** v 2.2.x or greater  
+* **TypeScript** experience
+* **Understanding** of Token-2022 program basics
+
+## Understanding Tokenized Attestations
+
+The token attestation program has two instructions that can create a token attestation: 
+1. [`create_attestation`](https://github.com/solana-foundation/solana-attestation-service/blob/master/program/src/processor/create_attestation.rs) and
+2. [`create_tokenized_attestation`](https://github.com/solana-foundation/solana-attestation-service/blob/master/program/src/processor/create_tokenized_attestation.rs)
+
+The `create_tokenized_attestation` performs all the [same actions](https://github.com/solana-foundation/solana-attestation-service/blob/e2f41faf7262c2bc3ac4b0160fbbc8c5bec71869/program/src/processor/create_tokenized_attestation.rs#L47-L52) as the `create_attestation` instruction and then also mints a representative soulbound NFT to the user. The NFT is a Token 2022 SPL token that leverage several Token Extensions (if you're new to Token 2022, check out our [Token Extension Guide](https://spl.solana.com/token-2022/extensions)):
+
+- **NonTransferable** - Prevents credential trading (soulbound)
+- **TokenMetadata** - Stores credential name, symbol, schema, and attestation account
+- **TokenGroupMember** - Links attestation tokens to a schema group
+- **PermanentDelegate** - Allows SAS authority to manage tokens
+- **MintCloseAuthority** - Enables credential revocation
+
+### When to Use Tokenized Attestations
+
+Choose **tokenized attestations** when you need:
+- **User-visible credentials** in standard wallets
+- **Integration** with existing SPL tooling/ecosystem infrastructure (e.g., [DAS API](https://developers.metaplex.com/das-api))
+- **Rich metadata** and branding (images, names, symbols, etc.)
+
+Tradeoffs:
+- **Higher Priority Fees** - tokenized attestations use additional compute (and therefore transactions will face higher priority fees)
+- **Higher Rent Costs** - tokenized attestations include an attestation account AND a token account, meaning users will need to cover additional costs for storing that data on-chain. The size of the account may vary slightly based on your metadata but are typically 0.005-0.006 SOL
+
+
+## Project Setup
+
+*Prefer to jump straight to the code? Check out our [Examples Repo on GitHub](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples) for the complete code.*
+
+If you completed the [fundamentals guide](/guides/ts/how-to-create-digital-credentials), you can add a new script to that project. Otherwise, create a new project:
+
+```shell
+mkdir tokenized-attestation-demo && cd tokenized-attestation-demo
+```
+
+Initialize and install dependencies:
+
+:::code-group
+ 
+```bash [npm]
+npm init -y
+npm i sas-lib gill
+npm i --save-dev typescript ts-node @types/node
+```
+ 
+```bash [pnpm]
+pnpm init
+pnpm i sas-lib gill
+pnpm i -D typescript ts-node @types/node
+```
+ 
+```bash [yarn]
+yarn init -y
+yarn add sas-lib gill
+yarn add -D typescript ts-node @types/node
+```
+ 
+:::
+
+Create a `tsconfig.json` file:
+
+```json
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "nodenext",
+    "lib": ["es2020"],
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "nodenext"
+  },
+  "rootDir": "./", 
+  "outDir": "./dist",
+  "include": ["./"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+Update your `package.json` scripts:
+
+```json
+"scripts": {
+  "test": "ts-node tokenized-attestation-demo.ts",
+  "build": "tsc"
+}
+```
+
+## Implementation
+
+Let's create our `tokenized-attestation-demo.ts` file and build it step by step:
+
+### Imports and Configuration
+
+Start with the necessary imports.
+
+```ts
+import {
+    getCreateCredentialInstruction,
+    getCreateSchemaInstruction,
+    serializeAttestationData,
+    fetchSchema,
+    fetchAttestation,
+    deserializeAttestationData,
+    deriveAttestationPda,
+    deriveCredentialPda,
+    deriveSchemaPda,
+    getTokenizeSchemaInstruction,
+    deriveSchemaMintPda,
+    deriveSasAuthorityAddress,
+    deriveAttestationMintPda,
+    getCreateTokenizedAttestationInstruction,
+    getCloseTokenizedAttestationInstruction,
+    SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS,
+    deriveEventAuthorityAddress,
+} from "sas-lib";
+import {
+    airdropFactory,
+    generateKeyPairSigner,
+    lamports,
+    Signature,
+    TransactionSigner,
+    IInstruction,
+    Address,
+    Blockhash,
+    getComputeUnitEstimateForTransactionMessageFactory,
+    createSolanaClient,
+    createTransaction,
+    SolanaClient
+} from "gill";
+import {
+    ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    fetchMint,
+    findAssociatedTokenPda,
+    getMintSize,
+    TOKEN_2022_PROGRAM_ADDRESS,
+} from "gill/programs";
+
+const CONFIG = {
+    // Network configuration 
+    CLUSTER_OR_RPC: 'devnet',
+
+    // Basic SAS Information
+    CREDENTIAL_NAME: 'TEST-ORGANIZATION',
+    SCHEMA_NAME: 'THE-BASICS',
+    SCHEMA_LAYOUT: Buffer.from([12, 0, 12]),
+    SCHEMA_FIELDS: ["name", "age", "country"],
+    SCHEMA_VERSION: 1,
+    SCHEMA_DESCRIPTION: 'Basic user information schema for testing',
+    ATTESTATION_DATA: {
+        name: "test-user",
+        age: 100,
+        country: "usa",
+    },
+    ATTESTATION_EXPIRY_DAYS: 365,
+
+    // Token Metadata
+    TOKEN_NAME: "Test Identity",
+    TOKEN_METADATA: "https://example.com/metadata.json",
+    TOKEN_SYMBOL: "TESTID",
+};
+```
+
+Notice there are a few new imports from our previous demo--this time leveraging several resources from the Token & Token 2022 Programs (via `gill/programs`). We have also added a few new metadata configuration fields that we will use for creating our attestation token: `TOKEN_NAME`, `TOKEN_METADATA`, and `TOKEN_SYMBOL`. 
+
+:::note
+
+Our config is set for devnet. If you prefer to use `localnet`, you will need to make sure to fetch the SAS program off mainnet by calling:<br/>
+`solana program dump -u m 22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG path/to/sas.so` <br/>
+and launching it with your test validator:<br/>
+
+`solana-test-validator -r --bpf-program 22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG path/to/sas.so`
+
+:::
+
+### Utility Functions
+
+Next, let's add a couple of utility functions to handle keypair management and transaction confirmations:
+
+
+```ts
+async function setupWallets(client: SolanaClient) {
+    try {
+        const payer = await generateKeyPairSigner(); // or loadKeypairSignerFromFile(path.join(process.env.PAYER));
+        const authorizedSigner1 = await generateKeyPairSigner();
+        const authorizedSigner2 = await generateKeyPairSigner();
+        const issuer = await generateKeyPairSigner();
+        const testUser = await generateKeyPairSigner();
+
+        const airdrop = airdropFactory({ rpc: client.rpc, rpcSubscriptions: client.rpcSubscriptions });
+        const airdropTx: Signature = await airdrop({
+            commitment: 'processed',
+            lamports: lamports(BigInt(1_000_000_000)),
+            recipientAddress: payer.address
+        });
+
+        console.log(`    - Airdrop completed: ${airdropTx}`);
+        return { payer, authorizedSigner1, authorizedSigner2, issuer, testUser };
+    } catch (error) {
+        throw new Error(`Failed to setup wallets: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+}
+
+async function sendAndConfirmInstructions(
+    client: SolanaClient,
+    payer: TransactionSigner,
+    instructions: IInstruction[],
+    description: string
+): Promise<Signature> {
+    try {
+        const simulationTx = createTransaction({
+            version: "legacy",
+            feePayer: payer,
+            instructions: instructions,
+            latestBlockhash: {
+                blockhash: '11111111111111111111111111111111' as Blockhash,
+                lastValidBlockHeight: 0n,
+            },
+            computeUnitLimit: 1_400_000,
+            computeUnitPrice: 1,
+        });
+
+        const estimateCompute = getComputeUnitEstimateForTransactionMessageFactory({ rpc: client.rpc });
+        const computeUnitLimit = await estimateCompute(simulationTx);
+        const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
+        const tx = createTransaction({
+            version: "legacy",
+            feePayer: payer,
+            instructions: instructions,
+            latestBlockhash,
+            computeUnitLimit,
+            computeUnitPrice: 1, // In production, use dynamic pricing
+        });
+
+        const signature = await client.sendAndConfirmTransaction(tx, {
+            skipPreflight: true,
+            commitment: "processed"
+        });
+        console.log(`    - ${description}: ${signature}`);
+        return signature;
+    } catch (error) {
+        throw new Error(`Failed to ${description.toLowerCase()}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+}
+
+async function verifyAttestation({
+    client,
+    schemaPda,
+    userAddress
+}: {
+    client: SolanaClient;
+    schemaPda: Address;
+    userAddress: Address;
+}): Promise<boolean> {
+    try {
+        const schema = await fetchSchema(client.rpc, schemaPda);
+        if (schema.data.isPaused) {
+            console.log(`    -  Schema is paused`);
+            return false;
+        }
+        const [attestationPda] = await deriveAttestationPda({
+            credential: schema.data.credential,
+            schema: schemaPda,
+            nonce: userAddress
+        });
+        const attestation = await fetchAttestation(client.rpc, attestationPda);
+        const attestationData = deserializeAttestationData(schema.data, attestation.data.data as Uint8Array);
+        console.log(`    - Attestation data:`, attestationData);
+        const currentTimestamp = BigInt(Math.floor(Date.now() / 1000));
+        return currentTimestamp < attestation.data.expiry;
+    } catch (error) {
+        return false;
+    }
+}
+```
+
+These are the same helper funcitons we've used before. Let's add one more that will allow us to also verify a user's token, `verifyTokenAttestation`:
+
+```ts
+async function verifyTokenAttestation({
+    client,
+    schemaPda,
+    userAddress
+}: {
+    client: SolanaClient;
+    schemaPda: Address;
+    userAddress: Address;
+}) {
+    try {
+        const schema = await fetchSchema(client.rpc, schemaPda);
+
+        const [attestationPda] = await deriveAttestationPda({
+            credential: schema.data.credential,
+            schema: schemaPda,
+            nonce: userAddress
+        });
+        const [attestationMint] = await deriveAttestationMintPda({
+            attestation: attestationPda
+        })
+        const mintAccount = await fetchMint(client.rpc, attestationMint);
+        if (!mintAccount) return false;
+        if (mintAccount.data.extensions.__option === 'None') {
+            return false;
+        }
+        const { value: foundExtensions } = mintAccount.data.extensions;
+
+        // Verify member of group
+        const [schemaMint] = await deriveSchemaMintPda({
+            schema: schemaPda
+        });
+        const tokenGroupMember = foundExtensions.find(ext => ext.__kind === 'TokenGroupMember');
+        if (!tokenGroupMember) return false;
+        if (tokenGroupMember.group !== schemaMint) return false;
+
+        // Verify token metadata
+        const tokenMetadata = foundExtensions.find(ext => ext.__kind === 'TokenMetadata');
+        if (!tokenMetadata) return false;
+                
+        // Verify attestation PDA matches
+        const attestationInMetadata = tokenMetadata.additionalMetadata.get('attestation');
+        if (attestationInMetadata !== attestationPda) return false;
+
+        // Verify schema PDA matches  
+        const schemaInMetadata = tokenMetadata.additionalMetadata.get('schema');
+        if (schemaInMetadata !== schemaPda) return false;
+
+        return true;
+
+    } catch {
+        return false;
+    }
+}
+```
+
+Let's walk through what this does:
+- First, we fetch the *Schema* so we can get the credential PDA (which is needed to derive the attestation PDA and attestation token mint)
+- Next, we fetch the attestation Mint
+- Finally, we run a series of checks on the mint account's extensions to ensure: 
+    - the token is a valid member of the schema mint group
+    - the token metadata includes a valid attestation PDA
+    - the token metadata includes a valid schema PDA
+
+:::warning
+_**Important:** attestation tokens do not have expiration data that is included in the standard attestation account, so this type of check should not be used to check active state of an attestation._
+:::
+
+### Steps 1-3: Setup
+
+Now let's implement the frame out the complete tokenized attestation workflow. Add the following `main` function to your file:
+
+```ts
+async function main() {
+    console.log("Starting Solana Attestation Service Demo\n");
+
+    const client: SolanaClient = createSolanaClient({ urlOrMoniker: CONFIG.CLUSTER_OR_RPC });
+
+    // Step 1: Setup wallets and fund payer
+    console.log("1. Setting up wallets and funding payer...");
+    const { payer, authorizedSigner1, authorizedSigner2, issuer, testUser } = await setupWallets(client);
+
+    // Step 2: Create Credential
+    console.log("\n2. Creating Credential...");
+    const [credentialPda] = await deriveCredentialPda({
+        authority: issuer.address,
+        name: CONFIG.CREDENTIAL_NAME
+    });
+
+    const createCredentialInstruction = getCreateCredentialInstruction({
+        payer,
+        credential: credentialPda,
+        authority: issuer,
+        name: CONFIG.CREDENTIAL_NAME,
+        signers: [authorizedSigner1.address, authorizedSigner2.address]
+    });
+
+    await sendAndConfirmInstructions(client, payer, [createCredentialInstruction], 'Credential created');
+    console.log(`    - Credential PDA: ${credentialPda}`);
+
+    // Step 3: Create Schema
+    console.log("\n3.  Creating Schema...");
+    const [schemaPda] = await deriveSchemaPda({
+        credential: credentialPda,
+        name: CONFIG.SCHEMA_NAME,
+        version: CONFIG.SCHEMA_VERSION
+    });
+
+    const createSchemaInstruction = getCreateSchemaInstruction({
+        authority: issuer,
+        payer,
+        name: CONFIG.SCHEMA_NAME,
+        credential: credentialPda,
+        description: CONFIG.SCHEMA_DESCRIPTION,
+        fieldNames: CONFIG.SCHEMA_FIELDS,
+        schema: schemaPda,
+        layout: CONFIG.SCHEMA_LAYOUT
+    });
+
+    await sendAndConfirmInstructions(client, payer, [createSchemaInstruction], 'Schema created');
+    console.log(`    - Schema PDA: ${schemaPda}`);
+
+    // Step 4: Tokenize Schema
+
+
+    // Step 5: Create Tokenized Attestation
+
+
+    // Step 6: Verify Attestations
+
+
+    // Step 7: Verify Attestation Token
+
+
+    // Step 8: Close Tokenized Attestation
+
+}
+
+main()
+    .then(() => console.log("\nSolana Attestation Service demo completed successfully!"))
+    .catch((error) => {
+        console.error("❌ Demo failed:", error);
+        process.exit(1);
+    });
+```
+
+Here, we are outlining the 8 steps we will follow in this tokenized attestation demo. We have included the first three steps, which leverage our [fundamentals guide](/guides/ts/how-to-create-digital-credentials#step-1-setup) - creating the foundational credential and schema infrastructure required for any SAS implementation. 
+
+1. Client and wallet setup - Initialize our Solana client and create the necessary keypairs for testing
+2. Create credential - Establish the issuing authority
+3. Create schema - Define the data structure for our attestations
+4. Tokenize schema - Create a tokenized schema as a Token-2022 "group" mint that we can associate our attestation tokens to
+5. Create tokenized attestation - Issue an attestation as a PDA and an SPL token
+6. Verify attestations - Demonstrate both standard and token-based verification methods
+7. Verify attestation token - Show how to validate tokenized credentials through Token-2022 extensions
+8. Close tokenized attestation - Demonstrate credential revocation by closing the attestation account and burning the NFT
+
+Let's build out the rest of our `main` function.
+
+### Step 4: Tokenize Schema
+
+Before utilizing tokenized attestations, you must first tokenize the schema. This create a "group token" associated with our schema that all attestation tokens will be members of. Under the hood, the SAS program leverages the Token 2022 [Group Pointer Extension](https://spl.solana.com/token-2022/extensions#group-pointer) ([source](https://github.com/solana-foundation/solana-attestation-service/blob/e2f41faf7262c2bc3ac4b0160fbbc8c5bec71869/program/src/processor/tokenize_schema.rs#L91-L97)). Add the following to your `main` function:
+
+```ts
+    // Step 4: Tokenize Schema
+    console.log("\n4. Tokenizing Schema...");
+    const [schemaMint] = await deriveSchemaMintPda({
+        schema: schemaPda
+    });
+    const sasPda = await deriveSasAuthorityAddress();
+    const schemaMintAccountSpace = getMintSize([
+        {
+            __kind: "GroupPointer",
+            authority: sasPda,
+            groupAddress: schemaMint
+        },
+    ]);
+
+    const createTokenizeSchemaInstruction = getTokenizeSchemaInstruction({
+        payer,
+        authority: issuer,
+        credential: credentialPda,
+        schema: schemaPda,
+        mint: schemaMint,
+        sasPda,
+        maxSize: schemaMintAccountSpace,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    })
+
+    await sendAndConfirmInstructions(client, payer, [createTokenizeSchemaInstruction], 'Schema tokenized');
+    console.log(`    - Schema Mint: ${schemaMint}`);
+```
+
+Let's break this down:
+- First, we utilize the `deriveSchemaMintPda` to get the Mint PDA associated with our `schemaPda`
+- Next, we use the `deriveSasAuthorityAddress` helper to get the PDA signer that will manage our tokens
+- Since SAS uses Extensions, we need to get the mint account size to tell the program how much space to allocate to the new mint program. We calculate that value by leveraging the `getMintSize` function and passing the `GroupPointer`. For more information on creating token mints, refer to [Guide: Create a Token Mint](https://solana.com/docs/tokens/basics/create-mint).
+- Finally we leverage `getTokenizeSchemaInstruction` to create our instruction and `sendAndConfirmInstructions` helper to send it to the network
+
+### Step 5: Create Tokenized Attestation
+
+Next we will create a transaction instruction that will create the tokenized attestation. Add the following to your code: 
+
+```ts
+    // Step 5: Create Tokenized Attestation
+    console.log("\n5. Creating Tokenized Attestation...");
+    const [attestationPda] = await deriveAttestationPda({
+        credential: credentialPda,
+        schema: schemaPda,
+        nonce: testUser.address
+    });
+    const [attestationMint] = await deriveAttestationMintPda({
+        attestation: attestationPda
+    })
+
+    const schema = await fetchSchema(client.rpc, schemaPda);
+    const expiryTimestamp = Math.floor(Date.now() / 1000) + (CONFIG.ATTESTATION_EXPIRY_DAYS * 24 * 60 * 60);
+    const [recipientTokenAccount] = await findAssociatedTokenPda({
+        mint: attestationMint,
+        owner: testUser.address,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    });
+
+    const attestationMintAccountSpace = getMintSize([
+        {
+            __kind: "GroupMemberPointer",
+            authority: sasPda,
+            memberAddress: attestationMint,
+        },
+        { __kind: "NonTransferable" },
+        {
+            __kind: "MetadataPointer",
+            authority: sasPda,
+            metadataAddress: attestationMint,
+        },
+        { __kind: "PermanentDelegate", delegate: sasPda },
+        { __kind: "MintCloseAuthority", closeAuthority: sasPda },
+        {
+            __kind: "TokenMetadata",
+            updateAuthority: sasPda,
+            mint: attestationMint,
+            name: CONFIG.TOKEN_NAME,
+            symbol: CONFIG.TOKEN_SYMBOL,
+            uri: CONFIG.TOKEN_METADATA,
+            additionalMetadata: new Map([
+                ["attestation", attestationPda],
+                ["schema", schemaPda]
+            ]),
+        },
+        {
+            __kind: "TokenGroupMember",
+            group: schemaMint,
+            mint: attestationMint,
+            memberNumber: 1,
+        },
+    ]);
+
+    const createTokenizedAttestationInstruction = await getCreateTokenizedAttestationInstruction({
+        payer,
+        authority: authorizedSigner1,
+        credential: credentialPda,
+        schema: schemaPda,
+        attestation: attestationPda,
+        schemaMint: schemaMint,
+        attestationMint,
+        sasPda,
+        recipient: testUser.address,
+        nonce: testUser.address,
+        expiry: expiryTimestamp,
+        data: serializeAttestationData(schema.data, CONFIG.ATTESTATION_DATA),
+        name:CONFIG.TOKEN_NAME,
+        uri: CONFIG.TOKEN_METADATA,
+        symbol: CONFIG.TOKEN_SYMBOL,
+        mintAccountSpace: attestationMintAccountSpace,
+        recipientTokenAccount: recipientTokenAccount,
+        associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    });
+
+    await sendAndConfirmInstructions(client, payer, [createTokenizedAttestationInstruction], 'Tokenized attestation created');
+    console.log(`    - Attestation PDA: ${attestationPda}`);
+    console.log(`    - Attestation Mint: ${attestationMint}`);
+```
+
+Like before, we will first derive our Attestation PDA using a helper function, `deriveAttestationPda` ([ref](/helpers#attestation-pda))--we must also derive the attestation mint using `deriveAttestationMintPda` ([ref](/helpers#schema-mint-pda)). Note that the parameters include a `nonce` which can be a user's address or some other unique identifier address (e.g. some value stored off-chain).
+
+Prior to calling `getCreateTokenizedAttestationInstruction`, we need to do a couple of things:
+- We must fetch our *Schema* from the chain--we will use `fetchSchema` to get the deserialized schema data which is required to serialize our attestation data. We do so by passing the schema data and our attestation into `serializeAttestationData`.
+- We define an expiration of 1-year from now.
+- We define a `recipientTokenAccount` address (where the token will be minted to) using `findAssociatedTokenPda`
+- We calculate the mint size using `getMintSize`. Creating a tokenized attestation involves several Token-2022 extensions, and we must include each or our instruction will fail:
+    - **GroupMemberPointer** - Links this token to the schema group
+    - **NonTransferable** - Prevents credential trading/transfers (soulbound)
+    - **MetadataPointer** - Points to on-chain metadata
+    - **PermanentDelegate** - Allows SAS authority to manage the token
+    - **MintCloseAuthority** - Enables credential revocation
+    - **TokenMetadata** - Stores human-readable information and references
+    - **TokenGroupMember** - Makes this token a member of the schema group
+
+_Notice that the `authority` in our instruction parameters is `authorizedSigner1`, the authorized signer we defined in Step 2 when we created our credential._
+
+Finally, we send the instruction to the network to create the attestation account and mint our attestation token.
+
+
+### Steps 6-7: Verification
+
+We can test that our attestation account was initiated by calling our `verifyAttestation`--add the following to your `main` function:
+
+```ts
+    // Step 6: Verify Attestations
+    console.log("\n6. Verifying Attestations...");
+
+    const isUserVerified = await verifyAttestation({
+        client,
+        schemaPda,
+        userAddress: testUser.address
+    });
+    console.log(`    - Test User is ${isUserVerified ? 'verified' : 'not verified'}`);
+```
+
+You can also run verification checks against the token mint, however, it is important to note that the tokenized attestation does not include expiary information, so to do a thorough verification you should use logic similar to the `verifyAttestation` function.
+
+For token verification, add the following to Step 7 of our code:
+
+```ts
+    // Step 7: Verify Attestation Token
+    console.log("\n7. Verifying Attestation Token...");
+    const isTokenVerified = await verifyTokenAttestation({ client, schemaPda, userAddress: testUser.address });
+    console.log(`    - Test User's token is ${isTokenVerified ? 'verified' : 'not verified'}`);
+```
+
+
+### Step 8: Close Tokenized Attestation
+
+Finally, let's run a script to close our attestation (and burn the associated NFT). Add Step 8:
+
+```ts
+    // Step 8: Close Tokenized Attestation
+    console.log("\n8. Closing Tokenized Attestations...");
+    const eventAuthority = await deriveEventAuthorityAddress();
+
+    const closeTokenizedAttestationInstruction = getCloseTokenizedAttestationInstruction({
+        payer,
+        authority: authorizedSigner1,
+        credential: credentialPda,
+        attestation: attestationPda,
+        eventAuthority,
+        attestationProgram: SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS,
+        attestationMint,
+        sasPda,
+        attestationTokenAccount: recipientTokenAccount,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+    });
+    await sendAndConfirmInstructions(client, payer, [closeTokenizedAttestationInstruction], 'Tokenized Attestation closed');
+```
+
+In order to generate an attesation instruction, we need to get the Event Authority address using `deriveEventAuthorityAddress`. The event authority is used to emit close events in the SAS program. Make sure to call `getCloseTokenizedAttestationInstruction` with an `authorizedSigner` and the proper token program (Token 2022).
+
+When we send this to the network, this will completely remove the token from the recipient's wallet via a [burn and close mint invocation](https://github.com/solana-foundation/solana-attestation-service/blob/e2f41faf7262c2bc3ac4b0160fbbc8c5bec71869/program/src/processor/close_tokenized_attestation.rs#L54-L75).
+
+
+## Run the Demonstration
+
+Execute the script:
+
+:::code-group
+ 
+```bash [npm]
+npm test
+```
+ 
+```bash [pnpm]
+pnpm test
+```
+ 
+```bash [yarn]
+yarn test
+```
+ 
+:::
+
+Expected output:
+
+```
+Starting Solana Attestation Service Demo
+
+1. Setting up wallets and funding payer...
+    - Airdrop completed: 2nzKSmVW4VxSzHeGtavx5b3fmG9qwa8oqkZK8Adp2pdKmSvMu6eNW6evUG6RjURJFFm1wfySzov2WHg8YNTv5Yju
+
+2. Creating Credential...
+    - Credential created: 3PJDtqk3FKxCBYA71gXdZKrRDgei9UNANvqwH3AkT8HMYXbTwBgn37xxoozUZKhupkr9wf3aH9hqgPcJehLAkL4C
+    - Credential PDA: 7mpL3XSdCN7v4mZZXcH3AfFQQKe62CT4a2EVxV66t3QE
+
+3.  Creating Schema...
+    - Schema created: mnoiU8AoxRhgkvGzLEyQzjsARyUp2SkQERHJmi9nziEW1eRADGzSJCdHECXathHxGs1xNF6b5m8E9TUVDWjmmrd
+    - Schema PDA: 9PCmekRX9szD6oK6JWCkvof9NCqgmufjjydPXWgnNC8w
+
+4. Tokenizing Schema...
+    - Schema tokenized: 3xDPohEPsHVE8a47vdFgjuirivg2iv4BWjnjPgTxYYxgSwo3MevSjXGCykpXE9oB3RZsWxGXagznE8uq99L4v1Ry
+    - Schema Mint: 45nkySibE1YpCEon9gw6kPVmRZyVsxjKjEZ3vnQgD617
+
+5. Creating Tokenized Attestation...
+    - Tokenized attestation created: 44vCrasFQqaaMcc5dDdfvoRUnRtDUWTubW6RMZzUn9GBGveVSMGTAmmMqWAgFZ9tFYXjWmNoVditSWqj1167DBdR
+    - Attestation PDA: HK8RKPGrPCaADrfMvkgyUrqYHH6LPCStjYDLR7VbgDYW
+    - Attestation Mint: 7zLCJNqkvuYkiWP5JMhVKCYh1B45SU2oPynbXfpphyc9
+
+6. Verifying Attestations...
+    - Attestation data: { name: 'test-user', age: 100, country: 'usa' }
+    - Test User is verified
+
+7. Verifying Attestation Token...
+    - Test User's token is verified
+
+8. Closing Tokenized Attestations...
+    - Tokenized Attestation closed: 3YSVy7Mfu3qCiSixaNiGzUfaqGJsouSbExEYv6kM3FQD9nAxZ9D3mu1MRxfTpGf98RTBFBv1GwsTZAhcCWjgqLR1
+
+Solana Attestation Service demo completed successfully!
+```
+
+Nice job!
+
+## Wrap Up
+
+Congratulations! You've successfully implemented a complete tokenized credential system using the Solana Attestation Service, including:
+
+- **Tokenize schemas** to create credential groups
+- **Issue tokenized attestations** as SPL tokens
+- **Verify credentials** through multiple methods
+- **Revoke credentials** by closing tokens
+
+Tokenized credentials open up new possibilities for credential management, user experience, and integration with the broader Solana ecosystem. Time to start building!
+
+## Additional Resources
+
+- Need help? Ask questions the [Solana Stack Exchange](https://solana.stackexchange.com/) with a `SAS` tag.
+- [Guide: How to Build Digital Credentials using Solana Attestation Service (TypeScript)](/guides/ts/how-to-create-digital-credentials)
+- [**SAS Source Code**](https://github.com/solana-foundation/solana-attestation-service)  
+- [**Complete Tokenized Example**](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/tokenized-typescript)  
+- [**Token-2022 Documentation**](https://spl.solana.com/token-2022)  
+- [**Solana Developer Resources**](https://solana.com/developers)

--- a/docs/pages/guides/ts/tokenized-attestations.mdx
+++ b/docs/pages/guides/ts/tokenized-attestations.mdx
@@ -56,7 +56,7 @@ Tradeoffs:
 
 ## Project Setup
 
-*Prefer to jump straight to the code? Check out our [Examples Repo on GitHub](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples) for the complete code.*
+*Prefer to jump straight to the code? Check out our [Examples Repo on GitHub](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript/attestation-flow-guides/src/tokenized-attestation-demo.ts) for the complete code.*
 
 If you completed the [fundamentals guide](/guides/ts/how-to-create-digital-credentials), you can add a new script to that project. Otherwise, create a new project:
 
@@ -749,6 +749,6 @@ Tokenized credentials open up new possibilities for credential management, user 
 - Need help? Ask questions the [Solana Stack Exchange](https://solana.stackexchange.com/) with a `SAS` tag.
 - [Guide: How to Build Digital Credentials using Solana Attestation Service (TypeScript)](/guides/ts/how-to-create-digital-credentials)
 - [**SAS Source Code**](https://github.com/solana-foundation/solana-attestation-service)  
-- [**Complete Tokenized Example**](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/tokenized-typescript)  
+- [**Complete Tokenized Example**](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript/attestation-flow-guides/src/tokenized-attestation-demo.ts)  
 - [**Token-2022 Documentation**](https://spl.solana.com/token-2022)  
 - [**Solana Developer Resources**](https://solana.com/developers)

--- a/docs/pages/instructions/close-tokenized-attestation.mdx
+++ b/docs/pages/instructions/close-tokenized-attestation.mdx
@@ -61,7 +61,7 @@ await transaction.sendAndConfirm();
 
 ## Related
 
-- [Attestations Documentation](../attestations)
-- [Credentials Documentation](../credentials)
+- [Attestations Documentation](/attestations)
+- [Credentials Documentation](/credentials)
 - [System Program Documentation](https://docs.solana.com/developing/runtime-facilities/programs#system-program)
 - [Token Program Documentation](https://spl.solana.com/token) 

--- a/docs/pages/schemas/index.mdx
+++ b/docs/pages/schemas/index.mdx
@@ -77,3 +77,51 @@ if (schema) {
 - The `version` field allows for schema evolution while maintaining backward compatibility
 - `layout` and `fieldNames` define the structure of credentials using this schema
 - All byte array fields (`name`, `description`, `layout`, `fieldNames`) should be properly encoded/decoded according to your application's needs
+
+### Schema Layout Data Types
+
+The `layout` field uses numeric values to specify data types for each field in the schema:
+
+| Value | Data Type | Description |
+|-------|-----------|-------------|
+| 0 | U8 | Unsigned 8-bit integer |
+| 1 | U16 | Unsigned 16-bit integer |
+| 2 | U32 | Unsigned 32-bit integer |
+| 3 | U64 | Unsigned 64-bit integer |
+| 4 | U128 | Unsigned 128-bit integer |
+| 5 | I8 | Signed 8-bit integer |
+| 6 | I16 | Signed 16-bit integer |
+| 7 | I32 | Signed 32-bit integer |
+| 8 | I64 | Signed 64-bit integer |
+| 9 | I128 | Signed 128-bit integer |
+| 10 | Bool | Boolean value |
+| 11 | Char | Single character |
+| 12 | String | Variable-length string |
+| 13 | VecU8 | Vector of unsigned 8-bit integers |
+| 14 | VecU16 | Vector of unsigned 16-bit integers |
+| 15 | VecU32 | Vector of unsigned 32-bit integers |
+| 16 | VecU64 | Vector of unsigned 64-bit integers |
+| 17 | VecU128 | Vector of unsigned 128-bit integers |
+| 18 | VecI8 | Vector of signed 8-bit integers |
+| 19 | VecI16 | Vector of signed 16-bit integers |
+| 20 | VecI32 | Vector of signed 32-bit integers |
+| 21 | VecI64 | Vector of signed 64-bit integers |
+| 22 | VecI128 | Vector of signed 128-bit integers |
+| 23 | VecBool | Vector of boolean values |
+| 24 | VecChar | Vector of characters |
+| 25 | VecString | Vector of strings |
+
+For example, a layout of `[12, 0, 12]` would define three fields: a String, followed by a U8 integer, followed by another String. The `fieldNames` array provides human-readable names that correspond positionally to each layout value, so with field names `["name", "age", "country"]`, the first String field would be named "name", the U8 field would be "age", and the second String field would be "country". Here's an example of how those would be utilized when creating a Schema:
+
+```ts
+    const createSchemaInstruction = getCreateSchemaInstruction({
+        authority,
+        payer,
+        credential: credentialPda,
+        schema: schemaPda,
+        name: "Test Schema",
+        description: "Just an example",
+        fieldNames: ["name", "age", "country"],
+        layout: Buffer.from([12, 0, 12]),
+    });
+```

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -84,6 +84,25 @@ export default defineConfig({
                     link: "/instructions/emit-event"
                 }
             ]
+        },
+        {
+            text: "Implementation Guides (TS)",
+            collapsed: false,
+            items: [
+                {
+                    text: "Attestation Fundamentals",
+                    link: "/guides/ts/how-to-create-digital-credentials"
+                },
+                {
+                    text: "Tokenized Attestations",
+                    link: "/guides/ts/tokenized-attestations"
+                },
+
+            ]
+        },
+        {
+            text: "Code Examples",
+            link: "https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/"
         }
     ],
 })


### PR DESCRIPTION
Adds two new TypeScript  implementation guides for SAS Flow:

- How to Build Digital Credentials using Solana Attestation Service
- How to Create Tokenized Credentials using Solana Attestation Service

### Changes
- Added `how-to-create-digital-credentials.mdx` - Standard attestation workflow example
- Added `tokenized-attestations.mdx` - Tokenized workflow example
- Updated `vocs.config.ts` - Add `Implementation Guides (TS)` section to sidebar
- Updated `schemas/index.mdx` - Added a table & example describing data type mapping used in the schema `layout` field
- Fixed `close-tokenized-attestation.mdx` - broken links for Attestations and Credentials documentation
- Deleted placeholder guide files in `docs/pages/guides/`

### Dependencies
- Links to new sample code: https://github.com/solana-foundation/solana-attestation-service/pull/84
- Requires fix to `deriveEventAuthorityAddress`: https://github.com/solana-foundation/solana-attestation-service/pull/83