### PR TITLE
Init SAS with Lit Encryption Guides

### DIFF
--- a/docs/pages/guides/ts/lit-encrypted-attestations/basic-attestation-flow.mdx
+++ b/docs/pages/guides/ts/lit-encrypted-attestations/basic-attestation-flow.mdx
@@ -203,6 +203,8 @@ yarn add \
 yarn add -D @lit-protocol/types
 ```
 
+:::
+
 Within your existing `solana-attestation-demo` directory, create a `lit` directory we can use to store our Lit related files:
 
 ```bash
@@ -464,7 +466,7 @@ To run this helper script, we'll add a new script to our `package.json` file:
 
 ```json
 "scripts": {
-  "generate-credential-pda": "ts-node src/lit/generate-credential-pda.ts",
+  "generate-credential-pda": "ts-node generate-credential-pda.ts",
 }
 ```
 
@@ -653,7 +655,7 @@ export function createSiwsMessage(siws: SiwsMessageInput): SiwsMessageForFormatt
 }
 ```
 
-_As with the rest of this guide, any imported custom types from the [`types.ts` file](#creating-a-types-file) we created previously._
+_As with the rest of this guide, any imported custom types are defined in the [`types.ts` file](#creating-a-types-file) we created previously._
 
 This helper function utilizes [Phantom's SIWS message specification](https://github.com/phantom/sign-in-with-solana/tree/main), and is used to prove the identity of a Credential signer to the Lit network. This SIWS message is part of the authorization process in our custom Lit Action that will gatekeep who is permitted to decrypt the attestation data.
 
@@ -844,7 +846,7 @@ export const decryptAttestationData = async ({
 }
 ```
 
-This functino is the main integration point for the Lit SDK, and it's responsible for setting up and executing the request to the Lit network to execute our custom Lit Action that authorizes decryption of the attestation data.
+This function is the main integration point for the Lit SDK, and it's responsible for setting up and executing the request to the Lit network to execute our custom Lit Action that authorizes decryption of the attestation data.
 
 For the input parameters for this function, we'll cover `litNodeClient` and `litPayerEthersWallet` in more detail later in this guide, and the remaining are as follows:
 
@@ -909,9 +911,7 @@ Session Signatures are created by specifying what `resourceAbilityRequests` are 
 
 For this guide, the identity of the person paying for the decryption request to the Lit network is irrelevant, as we're using the Lit Datil-dev network which doesn't actually charge for usage of the network, however we're still required to authenticate with the Lit network via a Session.
 
-If you'd like to transition this guide to use the Lit Datil-test or mainnet, you'll need to learn about [paying for usage of the Lit network](https://developer.litprotocol.com/paying-for-lit/overview).
-
-You can also learn more about how Session Signatures work, how to generate and customize them [here](https://developer.litprotocol.com/sdk/authentication/session-sigs/intro).
+If you'd like to transition this guide to use the Lit Datil-test or mainnet, you'll need to learn about [paying for usage of the Lit network](https://developer.litprotocol.com/paying-for-lit/overview). You can also learn more about how Session Signatures work, and how to customize them [here](https://developer.litprotocol.com/sdk/authentication/session-sigs/intro).
 
 ###### `jsParams`
 
@@ -932,6 +932,8 @@ Our custom Lit Action requires the raw SIWS message, the signature of the SIWS m
 
 Create the file `litActionDecrypt.ts` outside of the `lit` helpers directory (put the file in the same directory as the `attestation-demo.ts` file), and copy and paste the following code:
 
+:::details[Below we'll be diving into the Lit Action code, piece by piece, but click here to view the complete Lit Action Code.]
+
 ```ts
 // @ts-nocheck
 
@@ -939,7 +941,7 @@ const _litActionCode = async () => {
     // Hardcoded values for this specific attestation service instance
     const AUTHORIZED_RPC_URL = 'https://api.devnet.solana.com'
     const AUTHORIZED_PROGRAM_ID = '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG'
-    const AUTHORIZED_CREDENTIAL_PDA = '4MZk467hXkFjzWeog1SizZutKqKVTkbwvVKswap2QKeW'
+    const AUTHORIZED_CREDENTIAL_PDA = 'Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk'
 
     async function fetchAccountData(rpcUrl, address) {
         try {
@@ -1256,3 +1258,977 @@ const _litActionCode = async () => {
 
 export const litActionCode = `(${_litActionCode.toString()})()`
 ```
+
+:::
+
+##### The Structure of the Lit Action Code
+
+When providing the Lit Action code to the Lit SDK, you'll need to provide it as a stringified self executing function which looks like this:
+
+```ts
+const _litActionCode = async () => {
+    // Lit Action code...
+}
+
+export const litActionCode = `(${_litActionCode.toString()})()`
+```
+
+The `litActionCode` is the stringified self executing function, and what we imported and provide to the Lit SDK as the [code](#code) parameter to the `litNodeClient.executeJs` call.
+
+##### Hardcoded Solana Constants
+
+```ts
+const _litActionCode = async () => {
+    // Hardcoded values for this specific attestation service instance
+    const AUTHORIZED_RPC_URL = 'https://api.devnet.solana.com'
+    const AUTHORIZED_PROGRAM_ID = '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG'
+    const AUTHORIZED_CREDENTIAL_PDA = 'Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk'
+
+    // The rest of the Lit Action code...
+}
+```
+
+- The `AUTHORIZED_RPC_URL` is the RPC URL of the Solana cluster that the attestation service is running on.
+- The `AUTHORIZED_PROGRAM_ID` is the program ID of the attestation service.
+- The `AUTHORIZED_CREDENTIAL_PDA` is the Credential PDA that was derived from the Issuer keypair.
+    - This PDA is unique to your Issuer keypair and is used to identify whether the requestor of the decryption request is authorized to decrypt the attestation data.
+    - We generated this PDA earlier in the [Running the Generate Credential PDA Script](#running-the-generate-credential-pda-script) section:
+        ```bash
+        2. Creating Credential...
+        Credential PDA: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
+        ```
+
+##### Fetching Account Data
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    async function fetchAccountData(rpcUrl, address) {
+        try {
+            const response = await fetch(rpcUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'getAccountInfo',
+                    params: [address, { encoding: 'base64', commitment: 'confirmed' }],
+                }),
+            })
+
+            const data = await response.json()
+            if (data.error) {
+                throw new Error(`RPC error: ${data.error.message}`)
+            }
+
+            if (!data.result || !data.result.value) {
+                throw new Error('Account not found')
+            }
+
+            const accountInfo = data.result.value
+            return {
+                data: ethers.utils.base64.decode(accountInfo.data[0]),
+                owner: accountInfo.owner,
+            }
+        } catch (error) {
+            console.error('Error fetching account data:', error)
+            throw error
+        }
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `fetchAccountData` function is a utility method that allows the Lit Action to query Solana's blockchain state directly from within the secure execution environment. It fetches and decodes account data from Solana using the `getAccountInfo` RPC call, handling errors, and returning both the account's data and owner. This will enable the Lit Action to check which signers are authorized to decrypt the attestation later in the code.
+
+##### Parsing the Credential Account Data
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    function parseCredentialAccount(data) {
+        let offset = 0
+
+        // Skip discriminator (1 byte)
+        offset += 1
+
+        // Read authority (32 bytes)
+        const authority = ethers.utils.base58.encode(data.slice(offset, offset + 32))
+        offset += 32
+
+        // Read name length (4 bytes, little-endian)
+        const nameLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
+        offset += 4
+
+        // Skip name bytes
+        offset += nameLength
+
+        // Read authorized signers length (4 bytes, little-endian)
+        const signersLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
+        offset += 4
+
+        // Read authorized signers
+        const authorizedSigners = []
+        for (let i = 0; i < signersLength; i++) {
+            const signer = ethers.utils.base58.encode(data.slice(offset, offset + 32))
+            authorizedSigners.push(signer)
+            offset += 32
+        }
+
+        return { authority, authorizedSigners }
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `parseCredentialAccount` function deserializes the raw bytes returned from the Solana RPC into a readable credential account structure. It manually parses the binary data by reading specific byte offsets that correspond to the on-chain account layout: skipping the discriminator, extracting the authority public key, reading the name length and skipping those bytes, then finally extracting the list of authorized signers. This parsing is necessary because Solana stores account data as raw bytes, and we need to extract the authorized signers list to verify if the requesting signer has permission to decrypt the attestation data.
+
+##### Recreating the SIWS Message
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    function getSiwsMessage(siwsInput) {
+        console.log('Attempting to parse SIWS message: ', siwsInput)
+
+        if (!siwsInput.domain || !siwsInput.address) {
+            throw new Error('Domain and address are required for Siws message construction')
+        }
+
+        // Start with the mandatory domain and address line
+        let message = `${siwsInput.domain} wants you to sign in with your Solana account:\n${siwsInput.address}`
+
+        // Add statement if provided (with double newline separator)
+        if (siwsInput.statement) {
+            message += `\n\n${siwsInput.statement}`
+        }
+
+        // Collect advanced fields in the correct order as per ABNF spec
+        const fields = []
+
+        if (siwsInput.uri) {
+            fields.push(`URI: ${siwsInput.uri}`)
+        }
+        if (siwsInput.version) {
+            fields.push(`Version: ${siwsInput.version}`)
+        }
+        if (siwsInput.chainId) {
+            fields.push(`Chain ID: ${siwsInput.chainId}`)
+        }
+        if (siwsInput.nonce) {
+            fields.push(`Nonce: ${siwsInput.nonce}`)
+        }
+        if (siwsInput.issuedAt) {
+            fields.push(`Issued At: ${siwsInput.issuedAt}`)
+        }
+        if (siwsInput.expirationTime) {
+            fields.push(`Expiration Time: ${siwsInput.expirationTime}`)
+        }
+        if (siwsInput.notBefore) {
+            fields.push(`Not Before: ${siwsInput.notBefore}`)
+        }
+        if (siwsInput.requestId) {
+            fields.push(`Request ID: ${siwsInput.requestId}`)
+        }
+        if (siwsInput.resources && siwsInput.resources.length > 0) {
+            fields.push(`Resources:`)
+            for (const resource of siwsInput.resources) {
+                fields.push(`- ${resource}`)
+            }
+        }
+
+        // Add advanced fields if any exist (with double newline separator)
+        if (fields.length > 0) {
+            message += `\n\n${fields.join('\n')}`
+        }
+
+        return message
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `getSiwsMessage` function reconstructs the SIWS message string from the JSON input provided as `siwsMessage` in the [`jsParams` Lit Action parameter](#jsparams) within the secure Lit Action environment. This reconstruction is a critical security step that avoids trusting the message string passed as input (which could be manipulated), and instead rebuilds the message from its individual components according to Phantom's SIWS specification. This ensures the message structure matches what was originally signed by the user.
+
+##### Validating the SIWS Message
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    function validateSiwsMessage(siwsInput) {
+        const now = new Date()
+
+        // Check if message has expired (expirationTime is in the past)
+        if (siwsInput.expirationTime) {
+            const expirationTime = new Date(siwsInput.expirationTime)
+            if (now > expirationTime) {
+                return {
+                    valid: false,
+                    error: `SIWS message has expired. Current time: ${now.toISOString()}, Expiration: ${siwsInput.expirationTime}`,
+                }
+            }
+        }
+
+        // Check if message is not yet valid (notBefore is in the future)
+        if (siwsInput.notBefore) {
+            const notBefore = new Date(siwsInput.notBefore)
+            if (now < notBefore) {
+                return {
+                    valid: false,
+                    error: `SIWS message is not yet valid. Current time: ${now.toISOString()}, Not Before: ${siwsInput.notBefore}`,
+                }
+            }
+        }
+
+        return { valid: true }
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `validateSiwsMessage` function performs time-based validation on the SIWS message to prevent replay attacks and ensure the authentication request is fresh. It checks two optional time constraints: the `expirationTime` field to ensure the message hasn't expired, and the `notBefore` field to ensure the message isn't being used before its intended validity period.
+
+##### Verifying the SIWS Signature
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    async function verifySiwsSignature(siwsMessage, signerAddress, siwsMessageSignature) {
+        try {
+            const publicKey = await crypto.subtle.importKey(
+                'raw',
+                ethers.utils.base58.decode(signerAddress),
+                {
+                    name: 'Ed25519',
+                    namedCurve: 'Ed25519',
+                },
+                false,
+                ['verify']
+            )
+
+            const isValid = await crypto.subtle.verify(
+                'Ed25519',
+                publicKey,
+                ethers.utils.base58.decode(siwsMessageSignature),
+                new TextEncoder().encode(siwsMessage)
+            )
+
+            return isValid
+        } catch (error) {
+            console.error('Error in verifySiwsSignature:', error)
+            throw error
+        }
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `verifySiwsSignature` function performs cryptographic verification to confirm the SIWS message was actually signed by the claimed wallet address. It uses the Web Crypto API to import the public key from the Solana address (converting from Base58 format), then verifies the Ed25519 signature against the reconstructed message string. This cryptographic proof ensures that only someone with the private key corresponding to the claimed address could have created the signature, preventing impersonation attacks where malicious users might try to claim they control a wallet they don't actually own.
+
+##### Putting It All Together
+
+Now that we've covered the individual functions that make up the Lit Action code, let's put it all together to perform the SIWS message validation, and check if the message signer is authorized to decrypt the attestation data.
+
+The first steps is to parse the SIWS message into a JSON object, and reconstruct the SIWS message from the input parameters: `siwsMessage` to ensure the message is valid and not expired, or being used before its intended validity period:
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    const siwsMessageJson = JSON.parse(siwsMessage)
+    const siwsMessageString = getSiwsMessage(siwsMessageJson)
+
+    try {
+        const siwsMessageValid = validateSiwsMessage(siwsMessageJson)
+        if (!siwsMessageValid.valid) {
+            console.log('SIWS message validation failed:', siwsMessageValid.error)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'SIWS message validation failed.',
+                    error: siwsMessageValid.error,
+                }),
+            })
+        }
+    } catch (error) {
+        console.error('Error in validateSiwsMessage:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error in validateSiwsMessage.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+Next, we'll verify the SIWS signature to ensure the message was actually signed by the claimed wallet address:
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    try {
+        const siwsSignatureValid = await verifySiwsSignature(siwsMessageString, siwsMessageJson.address, siwsMessageSignature)
+
+        if (!siwsSignatureValid) {
+            console.log('Signature is invalid.')
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Signature is invalid.',
+                }),
+            })
+        }
+
+        console.log('Signature is valid.')
+    } catch (error) {
+        console.error('Error verifying signature:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error verifying signature.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+Then we perform the authorization check by fetching the hardcoded Credential account from Solana to verify decryption permissions. This involves a multi-step security validation:
+
+1. We confirm the credential account is owned by the legitimate Solana Attestation Service program (preventing attacks using fake credential accounts).
+2. We parse the account data to extract the authorized signers list.
+3. We verify that the authenticated wallet address from our SIWS message is actually included in this list of permitted decryption signers.
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    // Fetch and verify authorized signers from the hardcoded credential
+    try {
+        const accountInfo = await fetchAccountData(AUTHORIZED_RPC_URL, AUTHORIZED_CREDENTIAL_PDA)
+
+        // Verify the credential account is owned by the correct program
+        if (accountInfo.owner !== AUTHORIZED_PROGRAM_ID) {
+            console.log(`Credential PDA owner mismatch. Expected: ${AUTHORIZED_PROGRAM_ID}, Got: ${accountInfo.owner}`)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Credential PDA is not owned by the authorized program',
+                    expectedOwner: AUTHORIZED_PROGRAM_ID,
+                    actualOwner: accountInfo.owner,
+                }),
+            })
+        }
+
+        const credential = parseCredentialAccount(accountInfo.data)
+
+        // Check if the signer is authorized
+        const signerAddress = siwsMessageJson.address
+        if (!credential.authorizedSigners.includes(signerAddress)) {
+            console.log(`Signer ${signerAddress} is not in authorized signers list`)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Signer is not authorized to decrypt',
+                    authorizedSigners: credential.authorizedSigners,
+                    requestingSigner: signerAddress,
+                }),
+            })
+        }
+
+        console.log(`Signer ${signerAddress} is authorized to decrypt`)
+    } catch (error) {
+        console.error('Error checking authorized signers:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error checking authorized signers',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+Lastly, after validating the signer of the SIWS message is authorized to decrypt the attestation data, we can proceed to decrypt the attestation data using `Lit.Actions.decryptAndCombine`:
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    try {
+        const decryptedData = await Lit.Actions.decryptAndCombine({
+            accessControlConditions: [
+                {
+                    method: '',
+                    params: [':currentActionIpfsId'],
+                    pdaParams: [],
+                    pdaInterface: { offset: 0, fields: {} },
+                    pdaKey: '',
+                    chain: 'solana',
+                    returnValueTest: {
+                        key: '',
+                        comparator: '=',
+                        value: LitAuth.actionIpfsIds[0],
+                    },
+                },
+            ],
+            ciphertext,
+            dataToEncryptHash,
+            authSig: {
+                sig: ethers.utils.hexlify(ethers.utils.base58.decode(siwsMessageSignature)).slice(2),
+                derivedVia: 'solana.signMessage',
+                signedMessage: siwsMessageString,
+                address: siwsMessageJson.address,
+            },
+            chain: 'solana',
+        })
+        return LitActions.setResponse({ response: JSON.stringify({ success: true, decryptedData }) })
+    } catch (error) {
+        console.error('Error decrypting data:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error decrypting data.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `Lit.Actions.decryptAndCombine` function is part of the Lit Actions SDK and is available globally within the Lit node execution environment. When invoked, it initiates the distributed decryption process across the Lit network. Each participating Lit node checks whether the provided Access Control Conditions are satisfied, and if so, generates and shares its decryption share with the network. Once enough valid shares are collected (2/3 of the total Lit nodes), they are combined to reconstruct the decrypted data, which is then returned to the Lit Action.
+
+The parameters for `Lit.Actions.decryptAndCombine` are:
+
+- `accessControlConditions`: An array of Access Control Conditions that must be satisfied for the decryption to occur.
+- `ciphertext`: The ciphertext to decrypt that we fetched from the on-chain Attestation account.
+- `dataToEncryptHash`: The hash of the data to encrypt that we fetched from the on-chain Attestation account.
+- `authSig`: The signature of the SIWS message used by the Lit nodes to authenticate who's making the decryption request.
+- `chain`: The chain corresponding to the `authSig` parameter (in this case, `solana` because we're providing a signature using a Solana keypair).
+
+For a refresher on how the `accessControlConditions` parameter works, check out the [Access Control Conditions](#access-control-conditions) section we covered earlier.
+
+## Implementation
+
+Now that we've setup and covered all the parts of this demo, let's run it!
+
+The following demonstation script follows the same pattern as the [Basic Attestation Flow](/guides/ts/lit-encrypted-attestations/basic-attestation-flow) guide, but with some changes that demonstrate how to use the helper functions we created above to encrypt the attestation data.
+
+### Prerequisites
+
+- As [mentioned earlier](#running-the-generate-credential-pda-script), make sure to run the `generate-credential-pda` script to create the Issuer and Authorized Signers keypairs, as well as derive the Credential PDA.
+- Copy and paste the Credential PDA from the output of the script into the `AUTHORIZED_CREDENTIAL_PDA` variable in Lit Action (see [here](#hardcoded-credential-account) for more details).
+
+### Step 1: Setup
+
+Now, let's build the main demonstration function that showcases the complete attestation workflow. Add the `main` function to your code--we'll use this to outline for our steps:
+
+```ts
+let _litNodeClient: LitNodeClient | null = null
+
+async function main() {
+    console.log('Starting Solana Attestation Service with Lit Protocol encrypted attestation demo\n')
+
+    const client: SolanaClient = createSolanaClient({ urlOrMoniker: CONFIG.CLUSTER_OR_RPC })
+
+    // Step 1: Setup wallets and fund payer
+    console.log('1. Setting up wallets and funding payer...')
+    const { payer, authorizedSigner1, authorizedSigner2, issuer, testUser } = await setupWallets(client)
+
+    // Step 2: Setting up Lit
+
+    // Step 3: Setting up Credential
+
+    // Step 4: Createing Schema
+
+    // Step 5: Creating Attestation
+
+    // Step 6: Updating Authorized Signers
+
+    // Step 7: Verifying Attestation
+
+    // Step 8: Closing Attestation
+}
+```
+
+The current code includes spaces for 8 steps. We've started by creating our client and calling our `setupWallets` function. Let's add the remaining steps next.
+
+### Step 2: Setting up Lit
+
+This step is creating our Lit node client, connecting us to the Lit Datil-dev network. Additionally, the Ethereum wallet we'll be using as the payer for the decryption request is generated and returned to us. Add the following code to your `main` function after Step 1:
+
+_Note: remeber that while using the Lit Datil-dev network, payment is actually required, but providing a wallet is still required._
+
+```ts
+// Step 2: Setup Lit
+console.log('2. Setting up Lit...')
+const { litNodeClient, litPayerEthersWallet } = await setupLit()
+_litNodeClient = litNodeClient
+```
+
+### Step 3: Setting up Credential
+
+Next we're going to create our Credential account if it doesn't already exist, or fetch the existing one if it does.
+
+Unlike the [Basic Attestation Flow](/guides/ts/lit-encrypted-attestations/basic-attestation-flow) guide that always creates a new Credential keypair and account every time you run the demo, this demo reuses the Issuer keypair so that we have a static Credential PDA to use in out Lit Action.
+
+Add the following code to your `main` function after Step 2:
+
+```ts
+// Step 3: Create Credential (if it doesn't exist)
+console.log('\n3. Setting up Credential...')
+const [credentialPda] = await deriveCredentialPda({
+    authority: issuer.address,
+    name: CONFIG.CREDENTIAL_NAME,
+})
+
+try {
+    // Check if credential already exists
+    const existingCredential = await fetchCredential(client.rpc, credentialPda)
+    console.log(`    - Credential already exists: ${credentialPda}`)
+    console.log(`    - Authority: ${existingCredential.data.authority}`)
+    console.log(`    - Authorized signers: ${existingCredential.data.authorizedSigners.length}`)
+} catch (error) {
+    // Credential doesn't exist, create it
+    console.log(`    - Creating new credential: ${credentialPda}`)
+    const createCredentialInstruction = getCreateCredentialInstruction({
+        payer,
+        credential: credentialPda,
+        authority: issuer,
+        name: CONFIG.CREDENTIAL_NAME,
+        signers: [authorizedSigner1.address],
+    })
+
+    await sendAndConfirmInstructions(client, payer, [createCredentialInstruction], 'Credential created')
+    console.log(`    - Credential created successfully`)
+}
+```
+
+### Step 4: Create Schema
+
+Next, we need to define our _Schema_ to define the structure of data that can be attested (`ciphertext` and `dataToEncryptHash` in our example).
+
+Just like the Credential PDA, we're going to check if the Schema PDA already exists, and create it if it doesn't.
+
+Add the following code to your `main` function after Step 3:
+
+```ts
+// Step 4: Create Schema
+console.log('\n4.  Creating Schema...')
+const [schemaPda] = await deriveSchemaPda({
+    credential: credentialPda,
+    name: CONFIG.SCHEMA_NAME,
+    version: CONFIG.SCHEMA_VERSION,
+})
+
+try {
+    // Check if schema already exists
+    const existingSchema = await fetchSchema(client.rpc, schemaPda)
+    console.log(`    - Schema already exists: ${schemaPda}`)
+    console.log(`    - Schema name: ${new TextDecoder().decode(existingSchema.data.name)}`)
+    console.log(`    - Version: ${existingSchema.data.version}`)
+} catch (error) {
+    // Schema doesn't exist, create it
+    console.log(`    - Creating new schema: ${schemaPda}`)
+    const createSchemaInstruction = getCreateSchemaInstruction({
+        authority: issuer,
+        payer,
+        name: CONFIG.SCHEMA_NAME,
+        credential: credentialPda,
+        description: CONFIG.SCHEMA_DESCRIPTION,
+        fieldNames: CONFIG.SCHEMA_FIELDS,
+        schema: schemaPda,
+        layout: CONFIG.SCHEMA_LAYOUT,
+    })
+
+    await sendAndConfirmInstructions(client, payer, [createSchemaInstruction], 'Schema created')
+    console.log(`    - Schema created successfully`)
+}
+```
+
+### Step 5: Create Attestation
+
+Next, we need to issue an actual attestation to a specific user with the defined data and expiration.
+
+Because we're encrypting our attestation data, we need to first encrypt it using our `encryptAttestationData` helper function, and then create the attestation using the encryption metadata.
+
+Add the following code to your `main` function after Step 4:
+
+```ts
+// Step 5: Create and Encrypt Attestation
+console.log('\n5. Creating Attestation...')
+const [attestationPda] = await deriveAttestationPda({
+    credential: credentialPda,
+    schema: schemaPda,
+    nonce: testUser.address,
+})
+
+const schema = await fetchSchema(client.rpc, schemaPda)
+const expiryTimestamp = Math.floor(Date.now() / 1000) + CONFIG.ATTESTATION_EXPIRY_DAYS * 24 * 60 * 60
+
+const attestationEncryptionMetadata = await encryptAttestationData({
+    attestationData: new TextEncoder().encode(JSON.stringify(CONFIG.ATTESTATION_DATA)),
+    litNodeClient,
+})
+
+const createAttestationInstruction = getCreateAttestationInstruction({
+    payer,
+    authority: authorizedSigner1,
+    credential: credentialPda,
+    schema: schemaPda,
+    attestation: attestationPda,
+    nonce: testUser.address,
+    expiry: expiryTimestamp,
+    data: serializeAttestationData(schema.data, {
+        ...attestationEncryptionMetadata,
+    }),
+})
+
+await sendAndConfirmInstructions(client, payer, [createAttestationInstruction], 'Attestation created')
+console.log(`    - Attestation PDA: ${attestationPda}`)
+```
+
+### Step 6: Update Authorized Signers
+
+Next, let's add `authorizedSigner2` as an authorized signer to our credential to demonstrate how to manage who can issue attestations for the credential.
+
+Add the following code to your `main` function after Step 5:
+
+```ts
+// Step 6: Update Authorized Signers
+console.log('\n6. Updating Authorized Signers...')
+const changeAuthSignersInstruction = getChangeAuthorizedSignersInstruction({
+    payer,
+    authority: issuer,
+    credential: credentialPda,
+    signers: [authorizedSigner1.address, authorizedSigner2.address],
+})
+
+await sendAndConfirmInstructions(client, payer, [changeAuthSignersInstruction], 'Authorized signers updated')
+```
+
+### Step 7: Verify Attestation
+
+Let's run a verification check to show how you might check if users have valid attestations, testing both attested and non-attested users. Normally, you might run something like this on your backend when a user signs into your platform.
+
+Add the following code to your `main` function after Step 6:
+
+```ts
+// Step 7: Verify Attestation
+console.log('\n7. Verifying Attestations...')
+
+const isUserVerified = await verifyAttestation({
+    client,
+    schemaPda,
+    userAddress: testUser.address,
+    authorizedSigner: authorizedSigner1, // Use one of the authorized signers
+    litDecryptionParams: {
+        litNodeClient,
+        litPayerEthersWallet,
+    },
+})
+console.log(`    - Test User is ${isUserVerified.isVerified ? 'verified' : 'not verified'}`)
+if (isUserVerified.decryptedAttestationData) {
+    console.log(`    - Decrypted Attestation Data: ${isUserVerified.decryptedAttestationData}`)
+}
+
+const randomUser = await generateKeyPairSigner()
+const isRandomVerified = await verifyAttestation({
+    client,
+    schemaPda,
+    userAddress: randomUser.address,
+    authorizedSigner: authorizedSigner2, // Use the other authorized signer
+    litDecryptionParams: {
+        litNodeClient,
+        litPayerEthersWallet,
+    },
+})
+console.log(`    - Random User is ${isRandomVerified.isVerified ? 'verified' : 'not verified'}`)
+
+// Test with unauthorized signer (should fail)
+console.log('\n    Testing with unauthorized signer (should fail)...')
+const unauthorizedSigner = await generateKeyPairSigner()
+console.log(`    - Unauthorized signer address: ${unauthorizedSigner.address}`)
+
+const unauthorizedResult = await verifyAttestation({
+    client,
+    schemaPda,
+    userAddress: testUser.address,
+    authorizedSigner: unauthorizedSigner, // This signer is NOT in the credential
+    litDecryptionParams: {
+        litNodeClient,
+        litPayerEthersWallet,
+    },
+})
+
+if (unauthorizedResult.isVerified) {
+    console.log(`    - ❌ Unauthorized signer is verified`)
+} else {
+    console.log(`    - ✅ Unauthorized signer is not verified`)
+}
+```
+
+### Step 8: Close Attestation
+
+Finally, let's revoke an attestation from a user, and return the summary data for pretty printing.
+
+Add the following code to your `main` function after Step 7:
+
+```ts
+console.log('\n8. Closing Attestation...')
+
+const eventAuthority = await deriveEventAuthorityAddress()
+const closeAttestationInstruction = getCloseAttestationInstruction({
+    payer,
+    attestation: attestationPda,
+    authority: authorizedSigner1,
+    credential: credentialPda,
+    eventAuthority,
+    attestationProgram: SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS,
+})
+await sendAndConfirmInstructions(client, payer, [closeAttestationInstruction], 'Closed attestation')
+
+// Return summary data for pretty printing
+return {
+    addresses: {
+        credentialPda,
+        schemaPda,
+        attestationPda,
+        testUserAddress: testUser.address,
+    },
+    verification: isUserVerified,
+    randomVerification: isRandomVerified,
+    unauthorizedResult,
+    config: CONFIG,
+    attestationEncryptionMetadata,
+}
+```
+
+### Calling the Main Function
+
+The following code calls the `main` function we've just finished defining, validates the results, and also handles the pretty printing of the results.
+
+Add the following code after your `main` function to execute it:
+
+```ts
+main()
+    .then(results => {
+        console.log('\n' + '='.repeat(80))
+        console.log('SOLANA ATTESTATION SERVICE WITH LIT PROTOCOL ENCRYPTED ATTESTATION DEMO')
+        console.log('='.repeat(80))
+
+        console.log('\n📋 DEMO CONFIGURATION:')
+        console.log(`   Network: ${results.config.CLUSTER_OR_RPC}`)
+        console.log(`   Organization: ${results.config.CREDENTIAL_NAME}`)
+        console.log(`   Schema: ${results.config.SCHEMA_NAME} (v${results.config.SCHEMA_VERSION})`)
+
+        console.log('\n🔑 CREATED ACCOUNTS:')
+        console.log(`   Credential PDA:    ${results.addresses.credentialPda}`)
+        console.log(`   Schema PDA:        ${results.addresses.schemaPda}`)
+        console.log(`   Attestation PDA:   ${results.addresses.attestationPda}`)
+        console.log(`   Test User:         ${results.addresses.testUserAddress}`)
+
+        console.log('\n🧪 VERIFICATION TEST RESULTS:')
+
+        // Test User Verification
+        const testUserStatus = results.verification.isVerified ? '✅ PASSED' : '❌ FAILED'
+        console.log(`   Test User Verification:     ${testUserStatus}`)
+        if (results.verification.isVerified) {
+            console.log(`   Encrypted Metadata:`)
+            console.log(`     - Ciphertext: ${results.attestationEncryptionMetadata.ciphertext.substring(0, 50)}...`)
+            console.log(`     - Data Hash: ${results.attestationEncryptionMetadata.dataToEncryptHash}`)
+            if (results.verification.decryptedAttestationData) {
+                console.log(`   Decrypted Attestation Data: ${results.verification.decryptedAttestationData}`)
+            }
+        }
+
+        // Random User Verification (should fail)
+        const randomUserStatus = !results.randomVerification.isVerified ? '✅ PASSED' : '❌ FAILED'
+        console.log(`   Random User Verification:   ${randomUserStatus} (correctly rejected)`)
+
+        // Unauthorized Signer Test (should fail)
+        const unauthorizedStatus = !results.unauthorizedResult.isVerified ? '✅ PASSED' : '❌ FAILED'
+        console.log(`   Unauthorized Signer Test:   ${unauthorizedStatus} (correctly rejected)`)
+
+        const allTestsPassed = results.verification.isVerified && !results.randomVerification.isVerified && !results.unauthorizedResult.isVerified
+
+        if (allTestsPassed) {
+            console.log('   ✅ ALL TESTS PASSED! Demo completed successfully.')
+        } else {
+            console.log('   ❌ Some tests failed. Please review the results above.')
+        }
+
+        console.log('\n' + '='.repeat(80))
+    })
+    .catch(error => {
+        console.error('\n❌ Demo failed:', error)
+        process.exit(1)
+    })
+    .finally(() => {
+        _litNodeClient?.disconnect()
+    })
+```
+
+## Running the Demonstration
+
+To test your attestation workflow, run the script in your project terminal:
+
+:::code-group
+
+```bash [npm]
+npm start
+```
+
+```bash [pnpm]
+pnpm start
+```
+
+```bash [yarn]
+yarn start
+```
+
+:::
+
+Here's what you should expect to see in the output:
+
+```
+lit-js-sdk:constants:errors deprecated LitErrorKind is deprecated and will be removed in a future version. Use LIT_ERROR_KIND instead. node:internal/modules/cjs/loader:1692:14
+Starting Solana Attestation Service with Lit Protocol encrypted attestation demo
+
+1. Setting up wallets and funding payer...
+authorized-signer-1 keypair does not exist at path: key-pairs/authorized-signer-1.keypair.json. Generating it...
+Got Authorized Signer 1 keypair with address: 8XMEduQLuEw4LHGD6a66LeH1TKJsa3rpghGnM1mjbHCN
+authorized-signer-2 keypair does not exist at path: key-pairs/authorized-signer-2.keypair.json. Generating it...
+Got Authorized Signer 2 keypair with address: 8BDVzsSvqFFMDpcqcueTBVnPu33aqP72XJq3QUfGAeho
+Got Issuer keypair with address: EFjEXBpSHL7xXUNZEQf5CKWD7dZHkLfqc1i9tceoqms2
+    - Airdrop completed: 5oZPNTNhkXZDvEeKFDrwhwym49QCn8pvPTfFfZHjhMA9CR8Me29fXuFx4cRWFRwnTM37j4sCEh7DhUaapaygQ72r
+2. Setting up Lit...
+lit-js-sdk:constants:constants deprecated LogLevel is deprecated and will be removed in a future version. Use LOG_LEVEL instead. node_modules/.pnpm/@lit-protocol+core@7.2.1_typescript@5.8.3/node_modules/@lit-protocol/core/src/lib/lit-core.js:453:119
+
+3. Setting up Credential...
+    - Creating new credential: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
+    - Credential created - Signature: 2LtJedSKv7bKcoSLKLQxt2Woio8r4cxkXdcvxmTAEY1B8Y5TRHuddtnkQwQm6Gu7WLLnJsP9ZL5XCvBL67KAW8SH
+    - Credential created successfully
+
+4.  Creating Schema...
+    - Creating new schema: 9Zhbp3ybaZGnPQH6LHuC6fE51qu33g1byan9X34XGcqa
+    - Schema created - Signature: 4Uu4oSh6dFQg81ryXQsYiPwWgGSqg7rNpRSogAo4g3EVmzL8Z6h8qABviPQVEoqUENRJgkfnbgm7ttrLTPb1GhnR
+    - Schema created successfully
+
+5. Creating Attestation...
+using deprecated parameters for `initSync()`; pass a single object instead
+    - Attestation created - Signature: 3KBcnS3FnH1ACn1hPhEhGB9aMDLRvr31fC5fizMEC1Qiz38WEGEXgWqMhsyqEJabYoHWe5scSaxeMcvtBTdXnh7b
+    - Attestation PDA: 5Baypg1tZ6M1wmBKw56b5YZ6RV7AyJtrsyD5kVSZ9q3C
+
+6. Updating Authorized Signers...
+    - Authorized signers updated - Signature: 5zCcr9A3Z6ag4pCNHi4BwaSDdvqjZStJWBu43RgidvYYSLSwsf5mPbRHjNo41caVfAdHEgWgJ52QFRuWjopZn8KK
+
+7. Verifying Attestations...
+    - Attestation data: {
+  ciphertext: 'mBWDUTwA+LHxmhAbFGO3H+wc24rshZZgynWblL6IFsUxvbuipA2goo5Ps66i/4sH5ecEb/G67AE/1KvxyvhvUZCpagAWMYZvR6gg7q/5tVQvfEV6mL6XD9e9U0u00izx6ILiMUVJU/tnt2FNVNU6aTQC8IS4PSPGx6KIE+iSC68C',
+  dataToEncryptHash: '4efa888818ad5ba81b0e459037eb8c62a3f0bdf401de5372e21d8aa132a0a808'
+}
+Storage key "lit-session-key" is missing. Not a problem. Continue...
+Storage key "lit-wallet-sig" is missing. Not a problem. Continue...
+Unable to store walletSig in local storage. Not a problem. Continue...
+    - Test User is verified
+    - Decrypted Attestation Data: {"name":"test-user","age":100,"country":"usa"}
+    - Random User is not verified
+
+    Testing with unauthorized signer (should fail)...
+    - Unauthorized signer address: EHG46v4pFgRwtrfteCds1sApEvSJWnnN7iFkUGcMERAF
+    - Attestation data: {
+  ciphertext: 'mBWDUTwA+LHxmhAbFGO3H+wc24rshZZgynWblL6IFsUxvbuipA2goo5Ps66i/4sH5ecEb/G67AE/1KvxyvhvUZCpagAWMYZvR6gg7q/5tVQvfEV6mL6XD9e9U0u00izx6ILiMUVJU/tnt2FNVNU6aTQC8IS4PSPGx6KIE+iSC68C',
+  dataToEncryptHash: '4efa888818ad5ba81b0e459037eb8c62a3f0bdf401de5372e21d8aa132a0a808'
+}
+Storage key "lit-session-key" is missing. Not a problem. Continue...
+Storage key "lit-wallet-sig" is missing. Not a problem. Continue...
+Unable to store walletSig in local storage. Not a problem. Continue...
+There was an error while decrypting the attestation data: Error: An unexpected error occurred while decrypting the attestation data: Failed to decrypt attestation data: {"success":false,"message":"Signer is not authorized to decrypt","authorizedSigners":["8XMEduQLuEw4LHGD6a66LeH1TKJsa3rpghGnM1mjbHCN","8BDVzsSvqFFMDpcqcueTBVnPu33aqP72XJq3QUfGAeho"],"requestingSigner":"EHG46v4pFgRwtrfteCds1sApEvSJWnnN7iFkUGcMERAF"}
+    at decryptAttestationData (lit/decrypt-attestation-data.ts:80:15)
+    at processTicksAndRejections (node:internal/process/task_queues:105:5)
+    at async verifyAttestation (attestation-demo.ts:149:40)
+    at async main (attestation-demo.ts:334:32)
+    - ✅ Unauthorized signer is not verified
+
+7. Closing Attestation...
+    - Closed attestation - Signature: b6NFkqmsLTeCeLoWJocx2n152vx5TcLehA9R4i3piZefeGroBzv91Lesdwdsn61N1MnF4L7ETPv7z9f2TUmDXwK
+
+================================================================================
+SOLANA ATTESTATION SERVICE WITH LIT PROTOCOL ENCRYPTED ATTESTATION DEMO
+================================================================================
+
+📋 DEMO CONFIGURATION:
+   Network: devnet
+   Organization: LIT-ENCRYPTED-ATTESTATIONS
+   Schema: LIT-ENCRYPTED-METADATA (v1)
+
+🔑 CREATED ACCOUNTS:
+   Credential PDA:    Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
+   Schema PDA:        9Zhbp3ybaZGnPQH6LHuC6fE51qu33g1byan9X34XGcqa
+   Attestation PDA:   5Baypg1tZ6M1wmBKw56b5YZ6RV7AyJtrsyD5kVSZ9q3C
+   Test User:         FgHoHpy589aV5y6dKymwZ1okJ8nL6p8x4eqotf7rMMfj
+
+🧪 VERIFICATION TEST RESULTS:
+   Test User Verification:     ✅ PASSED
+   Encrypted Metadata:
+     - Ciphertext: mBWDUTwA+LHxmhAbFGO3H+wc24rshZZgynWblL6IFsUxvbuipA...
+     - Data Hash: 4efa888818ad5ba81b0e459037eb8c62a3f0bdf401de5372e21d8aa132a0a808
+   Decrypted Attestation Data: {"name":"test-user","age":100,"country":"usa"}
+   Random User Verification:   ✅ PASSED (correctly rejected)
+   Unauthorized Signer Test:   ✅ PASSED (correctly rejected)
+   ✅ ALL TESTS PASSED! Demo completed successfully.
+
+================================================================================
+```
+
+The `lit-js-sdk` logs are expected, and can be ignored, and the `There was an error while decrypting the attestation data` error is for our decryption attempt using an unauthorized signer in [Step 7](#step-7-verify-attestation).
+
+If you see `✅ ALL TESTS PASSED! Demo completed successfully.`, you've successfully completed the demo!
+
+## Wrap Up
+
+Congratulations! You've successfully implemented a complete Solana Attestation Service system using Lit Protocol to encrypt the attestation data. You now have a working demonstration that shows how to:
+
+- **Create credentials** that represent issuing authorities
+- **Define schemas** for encrypted attestation metadata (`ciphertext` and `dataToEncryptHash`)
+- **Encrypt attestation data using Lit Protocol** with custom access control conditions
+- **Issue encrypted attestations** to specific users, storing only Lit encryption metadata on-chain
+- **Manage authorized signers** for enhanced security and dynamic access control
+- **Verify and decrypt attestations** programmatically, ensuring only authorized signers can access the underlying data
+- **Close (revoke) attestations** as needed
+
+The Solana Attestation Service provides a powerful foundation for building trust and identity systems on Solana. Whether you're creating compliance systems, financial credentials, professional certifications, or gaming achievements, SAS gives you the tools to issue and verify claims in a decentralized, transparent way.
+
+**Want to learn more?** Check out our [Guide: Encrypted Tokenized Attestations with Lit Protocol](/guides/ts/lit-encrypted-attestations/tokenized-attestation-flow).
+
+## Additional Resources
+
+- Need help? Ask questions the [Solana Stack Exchange](https://solana.stackexchange.com/) with a `SAS` tag.
+- [**SAS Source Code**](https://github.com/solana-foundation/solana-attestation-service)
+- [**Complete Code Example**](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript/attestation-flow-guides/src/lit/sas-standard-lit-demo.ts)
+- [**Solana Developer Resources**](https://solana.com/developers)
+- [**Lit Protocol Documentation**](https://developer.litprotocol.com/)
+- [**Lit Protocol Builders Telegram Group**](https://t.me/+aa73FAF9Vp82ZjJh)

--- a/docs/pages/guides/ts/lit-encrypted-attestations/basic-attestation-flow.mdx
+++ b/docs/pages/guides/ts/lit-encrypted-attestations/basic-attestation-flow.mdx
@@ -1,0 +1,1258 @@
+---
+title: Encrypted Attestation Data with Lit Protocol
+description: Learn how to encrypt and control access to attestation data using Lit Protocol's decentralized key management network
+date: 2025-08-12
+---
+
+# Encrypted Attestation Data with Lit Protocol
+
+## Introduction
+
+When creating attestations on Solana, you may need to handle sensitive data that shouldn't be publicly visible on-chain. While blockchain provides transparency and immutability, certain attestation use cases require privacy controls - such as medical records, academic transcripts, or confidential business certifications.
+
+This guide demonstrates how to create **encrypted attestations** by combining Solana's attestation capabilities with [Lit Protocol](https://litprotocol.com), a decentralized key management network that enables secure encryption and programmable access control.
+
+### Why Lit Protocol?
+
+Lit Protocol provides a decentralized key management network that solves Web3's security dilemma: how to manage secrets without trusting centralized servers or burdening users with complex key management.
+
+#### Identity-Based Encryption Architecture
+
+Each Lit node runs in a Trusted Execution Environment (TEE) powered by sealed AMD SEV-SNP hardware that isolates key material from node operators.
+
+Lit's encryption uses Identity-Based Encryption with BLS signatures:
+
+1. **Network BLS key generation**: Participating Lit nodes collectively generate a network wide BLS public/private key pair using Distributed Key Generation (DKG)
+2. **Encryption process**: Data is encrypted using the network's BLS public key, with your access control conditions serving as the "identity"
+3. **Decryption policy**: The access control conditions (like wallet ownership, token holdings, or custom logic) become the identity that must be proven for decryption
+
+#### Threshold Decryption Process
+
+To decrypt data, a threshold of more than two-thirds of Lit nodes must collaborate, each providing a BLS signature share:
+
+1. **Policy verification**: Each node independently verifies that your access control conditions are met (checking on-chain state, signatures, etc.)
+2. **Signature share creation**: If conditions are satisfied, each node uses their BLS private key share to sign the identity (your access control policy)
+3. **Threshold reconstruction**: Once enough signature shares are collected, they're combined to create the complete BLS signature
+4. **Data decryption**: The reconstructed BLS signature serves as the decryption key to decrypt your ciphertext
+
+This Identity-Based Encryption approach ensures that decryption keys are generated on-demand only when authorization conditions are met, with no pre-shared secrets or centralized key storage.
+
+## Getting Started
+
+This guide will walk you through creating a complete encrypted attestation script that:
+
+- Creates credential and schema accounts on Solana
+- Encrypts sensitive attestation data using Lit Protocol's decentralized network
+- Stores the encrypted metadata on-chain, keeping the attestation data private
+- Implements SIWS (Sign In With Solana) authentication for decryption using Lit's Identity-Based Encryption, ensuring that only authorized signers can decrypt attestation data
+- Verifies attestations for both attested and non-attested users
+- Verifies that only authorized signers can decrypt attestation data
+- Closes an attestation (effectively revoking a user's credential)
+
+The end goal will be to see a working attestation system in action:
+
+```shell
+================================================================================
+SOLANA ATTESTATION SERVICE WITH LIT PROTOCOL ENCRYPTED ATTESTATION DEMO
+================================================================================
+
+📋 DEMO CONFIGURATION:
+   Network: localnet
+   Organization: LIT-ENCRYPTED-ATTESTATIONS
+   Schema: LIT-ENCRYPTED-METADATA (v1)
+
+🔑 CREATED ACCOUNTS:
+   Credential PDA:    HhU8FzCALX7XThBoPUQnJWAZMJdDeXctdxbedbT4kshV
+   Schema PDA:        HvLgB2BjQN3BzjQszYw6xuCCMpWPEkfs4b1YMrRBEp7H
+   Attestation PDA:   41Tx4apNq6tocjY4FK4QXpZoTeybaPo1hK328SwvpLRf
+   Test User:         JCRGgpTgaun9581uounx61RSmiMxN8KazEjdCnJbBdwB
+
+🧪 VERIFICATION TEST RESULTS:
+   Test User Verification:     ✅ PASSED
+   Encrypted Metadata:
+     - Ciphertext: plYShVUjPEdl69jWh54tjutxcBEjx7GiCYH1KKfnowhqUWOPkH...
+     - Data Hash: 4efa888818ad5ba81b0e459037eb8c62a3f0bdf401de5372e21d8aa132a0a808
+   Decrypted Attestation Data: {"name":"test-user","age":100,"country":"usa"}
+   Random User Verification:   ✅ PASSED (correctly rejected)
+   Unauthorized Signer Test:   ✅ PASSED (correctly rejected)
+   ✅ ALL TESTS PASSED! Demo completed successfully.
+
+================================================================================
+```
+
+### Prerequisites
+
+Before starting this guide, you should have:
+
+- [**Node.js**](https://nodejs.org/en/download) (v22 or later)
+- [**Solana CLI**](https://solana.com/docs/intro/installation) v 2.2.x or greater
+- [TypeScript](http://typescriptlang.org/) Experience
+
+Additionally, this guide builds on top of the [Basic Solana Attestation Flow](/guides/ts/how-to-create-digital-credentials) guide, so you should have a working implementation of that guide to add to before starting this one.
+
+## Understanding Lit Encryption
+
+To effectively use Lit Protocol for encrypted attestations, it's important to understand the key components and how they work together to provide secure, programmable access control.
+
+### Lit Actions
+
+Lit Actions are JavaScript programs that run inside the secure hardware (TEEs) of Lit nodes across the decentralized Lit Protocol network.
+
+They are similar to smart contracts, but can interact with both on-chain and off-chain data to perform complex authorization logic.
+
+Each Lit node independently executes the same Lit Action in isolation, and more than two-thirds of nodes must agree on the result for consensus. This allows Lit Actions to securely:
+
+- Fetch data from external APIs (like Solana RPC endpoints).
+- Perform complex authorization logic.
+- Only authorize decryption when specific conditions are met.
+
+The Lit Action for this attestation demo acts as an authorization gatekeeper for decryption. It performs four key checks:
+
+1. **SIWS Authentication**: Validates the SIWS message, ensuring correct format, unexpired timestamp, and a valid signature from the claimed wallet.
+2. **Credential Verification**: Fetches the credential account from Solana, confirming its existence, correct program ownership, and data integrity.
+3. **Authorization**: Checks if the SIWS wallet address is listed as an authorized signer in the credential.
+4. **Conditional Decryption**: Only if all checks pass, the Lit Action decrypts and returns the attestation data; otherwise, access is denied.
+
+This ensures only explicitly authorized wallets can decrypt attestation data.
+
+### Access Control Conditions
+
+Access Control Conditions (ACCs) are the rules that determine who can decrypt your data, and under what circumstances. The Lit network will only allow decryption if these specific conditions are met.
+
+For this attestation demo, the ACCs are structured as:
+
+```typescript
+import ipfsOnlyHash from 'typestub-ipfs-only-hash'
+
+// This is the custom Lit Action created for this demo,
+// we'll be diving into it's implementation later in this guide
+import { litActionCode as litActionCodeDecrypt } from '../litActionDecrypt'
+
+const accessControlConditions = [
+    {
+        method: '',
+        params: [':currentActionIpfsId'],
+        pdaParams: [],
+        pdaInterface: { offset: 0, fields: {} },
+        pdaKey: '',
+        chain: 'solana',
+        returnValueTest: {
+            key: '',
+            comparator: '=',
+            value: await ipfsOnlyHash.of(litActionCodeDecrypt),
+        },
+    },
+]
+```
+
+Let's break down what each field means:
+
+- `params: [':currentActionIpfsId']`: A special parameter that gets the [IPFS CID](https://docs.ipfs.tech/concepts/content-addressing/) of the currently executing Lit Action
+- `chain: 'solana'`: Tells Lit Protocol this condition involves the Solana blockchain
+- `returnValueTest`: The authorization logic that must be satisfied for decryption to be permitted
+    - `comparator: '='`: The boolean operator used for comparison
+    - `value: await ipfsOnlyHash.of(litActionCodeDecrypt)`: The IPFS CID of our specific custom Lit Action for decryption
+
+This ACC is essentially saying:
+
+> "Only allow decryption if the request is coming from the Lit Action we specifically designed for authorizing attestation decryption."
+
+Since the Lit Action contains all the business logic for checking SIWS authentication and Solana credential authorization, this ACC ensures only authorized signers of the Solana credential can decrypt the attestation data.
+
+### Encryption Metadata
+
+When Lit encrypts your attestation data, it returns two crucial pieces of metadata that are required for decryption:
+
+- `ciphertext`: This is the actual encrypted version of your sensitive attestation data.
+- `dataToEncryptHash`: A cryptographic hash of the original data and the ACCs used to encrypted the data.
+
+## Project Setup
+
+_Prefer to jump straight to the code? Check out our [Examples Repo on GitHub](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript/attestation-flow-guides/src/lit/sas-standard-lit-demo.ts) for the complete code for this guide\!_
+
+As mentioned above, this guide builds on top of the [Basic Solana Attestation Flow](/guides/ts/how-to-create-digital-credentials) guide, so make sure you have a working implementation of that guide to add to before continuing with this one.
+
+Let's start by adding the necessary dependencies to encrypt our attestation data with Lit:
+
+:::code-group
+
+```bash [npm]
+npm init -y
+npm i \
+    @lit-protocol/auth-helpers \
+    @lit-protocol/constants \
+    @lit-protocol/lit-node-client \
+npm i --save-dev @lit-protocol/types
+```
+
+```bash [pnpm]
+pnpm init
+pnpm i \
+    @lit-protocol/auth-helpers \
+    @lit-protocol/constants \
+    @lit-protocol/lit-node-client \
+pnpm i -D @lit-protocol/types
+```
+
+```bash [yarn]
+yarn init -y
+yarn add \
+    @lit-protocol/auth-helpers \
+    @lit-protocol/constants \
+    @lit-protocol/lit-node-client \
+yarn add -D @lit-protocol/types
+```
+
+Within your existing `solana-attestation-demo` directory, create a `lit` directory we can use to store our Lit related files:
+
+```bash
+mkdir lit
+```
+
+### Creating a Types file
+
+We'll cover each of the following types as we use them in this guide, but for now, let's create a `types.ts` file that will contain the types we'll be using:
+
+```ts
+/**
+ * Sign-in With Solana (Siws) messages (following Phantom's specification)
+ * https://github.com/phantom/sign-in-with-solana/tree/main
+ */
+export interface SiwsMessage {
+    /**
+     * Optional EIP-4361 domain requesting the sign-in.
+     * If not provided, the wallet must determine the domain to include in the message.
+     */
+    domain?: string
+    /**
+     * Optional Solana address performing the sign-in. The address is case-sensitive.
+     * If not provided, the wallet must determine the Address to include in the message.
+     */
+    address?: string
+    /**
+     * Optional EIP-4361 Statement. The statement is a human readable string and should not have new-line characters (\n).
+     * If not provided, the wallet must not include Statement in the message.
+     */
+    statement?: string
+    /**
+     * Optional EIP-4361 URI. The URL that is requesting the sign-in.
+     * If not provided, the wallet must not include URI in the message.
+     */
+    uri?: string
+    /**
+     * Optional EIP-4361 version.
+     * If not provided, the wallet must not include Version in the message.
+     */
+    version?: string
+    /**
+     * Optional EIP-4361 Chain ID.
+     * The chainId can be one of the following: mainnet, testnet, devnet, localnet, solana:mainnet, solana:testnet, solana:devnet.
+     * If not provided, the wallet must not include Chain ID in the message.
+     */
+    chainId?: string
+    /**
+     * Optional EIP-4361 Nonce.
+     * It should be an alphanumeric string containing a minimum of 8 characters.
+     * If not provided, the wallet must not include Nonce in the message.
+     */
+    nonce?: string
+    /**
+     * Optional ISO 8601 datetime string.
+     * This represents the time at which the sign-in request was issued to the wallet.
+     * Note: For Phantom, issuedAt has a threshold and it should be within +/- 10 minutes from the timestamp at which verification is taking place.
+     * If not provided, the wallet must not include Issued At in the message.
+     */
+    issuedAt?: string
+    /**
+     * Optional ISO 8601 datetime string.
+     * This represents the time at which the sign-in request should expire.
+     * If not provided, the wallet must not include Expiration Time in the message.
+     */
+    expirationTime?: string
+    /**
+     * Optional ISO 8601 datetime string.
+     * This represents the time at which the sign-in request becomes valid.
+     * If not provided, the wallet must not include Not Before in the message.
+     */
+    notBefore?: string
+    /**
+     * Optional EIP-4361 Request ID.
+     * In addition to using nonce to avoid replay attacks, dapps can also choose to include a unique signature in the requestId.
+     * Once the wallet returns the signed message, dapps can then verify this signature against the state to add an additional, strong layer of security.
+     * If not provided, the wallet must not include Request ID in the message.
+     */
+    requestId?: string
+    /**
+     * Optional EIP-4361 Resources.
+     * Usually a list of references in the form of URIs that the dapp wants the user to be aware of.
+     * These URIs should be separated by \n-, i.e., URIs in new lines starting with the character '-'.
+     * If not provided, the wallet must not include Resources in the message.
+     */
+    resources?: string[]
+}
+
+/**
+ * Type-safe Siws message for formatting - requires mandatory fields domain and address
+ */
+export interface SiwsMessageForFormatting extends SiwsMessage {
+    domain: string // Required for message construction
+    address: string // Required for message construction
+}
+
+/**
+ * Input for createSiwsMessage - requires address, all other fields optional
+ */
+export interface SiwsMessageInput extends Partial<SiwsMessage> {
+    address: string // Address is mandatory for creation
+}
+
+export interface AttestationEncryptionMetadata {
+    ciphertext: string
+    dataToEncryptHash: string
+}
+
+export interface PkpInfo {
+    ethAddress: string
+    publicKey: string
+    tokenId: string
+}
+
+export interface LitDecryptionResponse {
+    success: boolean
+    message: string
+    error?: string
+    authorizedSigners?: string[]
+    requestingSigner?: string
+    decryptedData?: string
+}
+```
+
+## Updating the Existing Attestation Implementation
+
+Let's update the existing file, `attestation-demo.ts`, as well as create our Lit related files that allow us to encrypted our attestation data:
+
+### Imports and Configuration
+
+Start with the adding necessary imports:
+
+_Add these dependencies to the existing ones from the Basic Solana Attestation Flow guide._
+
+```ts
+import type { LitNodeClient } from '@lit-protocol/lit-node-client'
+import { fetchCredential } from 'sas-lib'
+import { KeyPairSigner } from 'gill'
+import { ethers } from 'ethers'
+```
+
+Next, update the existing configuration:
+
+```ts
+const CONFIG = {
+    CLUSTER_OR_RPC: 'devnet',
+    CREDENTIAL_NAME: 'LIT-ENCRYPTED-ATTESTATIONS',
+    SCHEMA_NAME: 'LIT-ENCRYPTED-METADATA',
+    SCHEMA_LAYOUT: Buffer.from([12, 12]),
+    SCHEMA_FIELDS: ['ciphertext', 'dataToEncryptHash'],
+    SCHEMA_VERSION: 1,
+    SCHEMA_DESCRIPTION: 'Schema for Lit Protocol encrypted attestation metadata with access control conditions',
+    ATTESTATION_DATA: {
+        name: 'test-user',
+        age: 100,
+        country: 'usa',
+    },
+    ATTESTATION_EXPIRY_DAYS: 365,
+}
+```
+
+Previously, the configuration's `SCHEMA_FIELDS` specified the individual properties of the attestation data. However, now that we'll be encrypting the attestation data, the schema defines the Lit encryption metadata (`ciphertext` and `dataToEncryptHash`) that will be stored on-chain instead, and used for decryption.
+
+For this example, the `SCHEMA_LAYOUT` is set to `Buffer.from([12, 12])` which corresponds to two fields:
+
+- the first `12` represents a String type for the `ciphertext` field,
+- the second `12` represents a String type for the `dataToEncryptHash` field.
+
+### Utility Functions
+
+Next, we're going to make some modifications to the existing `setupWallets` helper function. Instead of generating new keypairs for `authorizedSigner1`, `authorizedSigner2`, and `issuer` every time we run the script, we're going to generate them once and same them to a keyfile.
+
+This is because we need to have a static and predetermined Credential PDA address that will be hardcoded within our Lit Action that handles the authorization checks and decryption. Hardcoding the Credential PDA allows the Lit Action to enforce that only authorized signers for the specific Credential are authorized to decrypt the attestation data.
+
+#### Creating the Authorized Signer and Issuer Keypairs
+
+Let's start by creating a new `get-keypair.ts` file that will handle generating new keypairs, saving them to a keyfile, and loading them from the keyfile:
+
+```ts
+import { existsSync, mkdirSync } from 'fs'
+import { generateExtractableKeyPairSigner } from 'gill'
+import { loadKeypairSignerFromFile, saveKeypairSignerToFile } from 'gill/node'
+import path from 'path'
+
+async function generateKeypair(outputPath: string) {
+    const extractableSigner = await generateExtractableKeyPairSigner()
+    await saveKeypairSignerToFile(extractableSigner, outputPath)
+}
+
+async function getKeyPair(keyPairName: string) {
+    const keyPairDir = 'key-pairs'
+    const keyPairPath = path.join(keyPairDir, `${keyPairName}.keypair.json`)
+    if (!existsSync(keyPairPath)) {
+        // Ensure the directory exists before creating the file
+        if (!existsSync(keyPairDir)) {
+            mkdirSync(keyPairDir, { recursive: true })
+        }
+        console.log(`${keyPairName} keypair does not exist at path: ${keyPairPath}. Generating it...`)
+        await generateKeypair(keyPairPath)
+    }
+
+    return loadKeypairSignerFromFile(keyPairPath)
+}
+
+export async function getIssuerKeypair() {
+    const keypair = await getKeyPair('issuer')
+    console.log(`Got Issuer keypair with address: ${keypair.address}`)
+    return keypair
+}
+
+export async function getAuthorizedSigner1Keypair() {
+    const keypair = await getKeyPair('authorized-signer-1')
+    console.log(`Got Authorized Signer 1 keypair with address: ${keypair.address}`)
+    return keypair
+}
+
+export async function getAuthorizedSigner2Keypair() {
+    const keypair = await getKeyPair('authorized-signer-2')
+    console.log(`Got Authorized Signer 2 keypair with address: ${keypair.address}`)
+    return keypair
+}
+```
+
+#### Deriving the Credential PDA from the Issuer Keypair
+
+Next we'll create a new helper script called `generate-credential-pda.ts` that will generate a new or load an existing Issuer keypair, and use it to derive the Credential PDA address:
+
+```ts
+import { deriveCredentialPda } from 'sas-lib'
+
+import { getIssuerKeypair } from './get-keypair'
+
+async function main() {
+    console.log('Starting credential PDA generator\n')
+
+    // Step 1: Get issuer keypair
+    console.log('1. Getting Issuer keypair...')
+    const issuer = await getIssuerKeypair()
+
+    // Step 2: Create Credential
+    console.log('\n2. Creating Credential...')
+    const [credentialPda] = await deriveCredentialPda({
+        authority: issuer.address,
+        name: 'LIT-ENCRYPTED-METADATA',
+    })
+
+    console.log(`Credential PDA: ${credentialPda}`)
+}
+
+main()
+    .then(() => console.log('\nCredential PDA generated successfully!'))
+    .catch(error => {
+        console.error('❌ Failed to generate credential PDA:', error)
+        process.exit(1)
+    })
+```
+
+To run this helper script, we'll add a new script to our `package.json` file:
+
+```json
+"scripts": {
+  "generate-credential-pda": "ts-node src/lit/generate-credential-pda.ts",
+}
+```
+
+##### Running the Generate Credential PDA Script
+
+Before continuing with this guide, you'll need to run this script which will generate the Issuer keypair and Credential PDA, and save their keyfiles to a directory called `key-pairs`. After running the script, you should see output similar to:
+
+```bash
+pnpm generate-credential-pda
+
+> solana-attestation-demo-ts@1.0.0 generate-credential-pda attestation-flow-guides
+> ts-node src/lit/generate-credential-pda.ts
+
+Starting credential PDA generator
+
+1. Getting Issuer keypair...
+issuer keypair does not exist at path: key-pairs/issuer.keypair.json. Generating it...
+Got Issuer keypair with address: EFjEXBpSHL7xXUNZEQf5CKWD7dZHkLfqc1i9tceoqms2
+
+2. Creating Credential...
+Credential PDA: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
+
+Credential PDA generated successfully!
+```
+
+The line: `Credential PDA: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk` is important and what we'll need to hardcode into our Lit Action later in this guide.
+
+#### Updating the Setup Wallets Function
+
+Now that we have our keyfiles generated, and some helper functions to load them, we can update the `setupWallets` function to load the keypairs from the keyfiles instead of generating new ones every time.
+
+First add the import in the `attestation-demo.ts` file:
+
+```ts
+import { getAuthorizedSigner1Keypair, getAuthorizedSigner2Keypair, getIssuerKeypair } from './get-keypair'
+```
+
+Then update the `setupWallets` function to load the keypairs from the keyfiles:
+
+```ts
+async function setupWallets(client: SolanaClient) {
+    try {
+        const payer = await generateKeyPairSigner()
+        const authorizedSigner1 = await getAuthorizedSigner1Keypair() // <-- Load from keyfile using our helper function
+        const authorizedSigner2 = await getAuthorizedSigner2Keypair() // <-- Load from keyfile using our helper function
+        const issuer = await getIssuerKeypair() // <-- Load from keyfile using our helper function
+        const testUser = await generateKeyPairSigner()
+
+        const airdrop = airdropFactory({ rpc: client.rpc, rpcSubscriptions: client.rpcSubscriptions })
+        const airdropTx: Signature = await airdrop({
+            commitment: 'processed',
+            lamports: lamports(BigInt(1_000_000_000)),
+            recipientAddress: payer.address,
+        })
+
+        console.log(`    - Airdrop completed: ${airdropTx}`)
+        return { payer, authorizedSigner1, authorizedSigner2, issuer, testUser }
+    } catch (error) {
+        throw new Error(`Failed to setup wallets: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    }
+}
+```
+
+This is a key change to the existing Basic Solana Attestation Flow, and without it, we'll be unable to setup our Lit Action to properly authenticate Credential signers when they make requests to Lit to decrypt the attestation data.
+
+### Updating the Attestation Verification Function
+
+We'll be modifying the existing `verifyAttestation` function to handle retrieving the Lit encryption metadata from the on-chain attestation data, and decrypting by submitting a signed Sign-in-with-Solana (SIWS) message to our custom decryption Lit Action.
+
+_Make sure to add the following imports to the top of the file:_
+
+```ts
+import { createSiwsMessage, decryptAttestationData, signSiwsMessage } from './lit-helpers'
+import { AttestationEncryptionMetadata } from './types'
+```
+
+```ts
+async function verifyAttestation({
+    client,
+    schemaPda,
+    userAddress,
+    authorizedSigner,
+    litDecryptionParams,
+}: {
+    client: SolanaClient
+    schemaPda: Address
+    userAddress: Address
+    authorizedSigner: KeyPairSigner
+    litDecryptionParams: {
+        litNodeClient: LitNodeClient
+        litPayerEthersWallet: ethers.Wallet
+    }
+}): Promise<{ isVerified: boolean; decryptedAttestationData: string | null }> {
+    try {
+        const schema = await fetchSchema(client.rpc, schemaPda)
+        if (schema.data.isPaused) {
+            console.log(`    -  Schema is paused`)
+            return { isVerified: false, decryptedAttestationData: null }
+        }
+        const [attestationPda] = await deriveAttestationPda({
+            credential: schema.data.credential,
+            schema: schemaPda,
+            nonce: userAddress,
+        })
+        const attestation = await fetchAttestation(client.rpc, attestationPda)
+        const attestationData = deserializeAttestationData(schema.data, attestation.data.data as Uint8Array) as AttestationEncryptionMetadata
+        console.log(`    - Attestation data:`, attestationData)
+
+        let decryptedAttestationData: string | null = null
+        try {
+            const siwsMessage = createSiwsMessage({
+                address: authorizedSigner.address,
+                domain: 'localhost',
+                uri: 'http://localhost',
+                version: '1',
+            })
+            const siwsMessageSignature = await signSiwsMessage(siwsMessage, authorizedSigner)
+
+            decryptedAttestationData = (await decryptAttestationData({
+                ...litDecryptionParams,
+                ...attestationData,
+                siwsMessage,
+                siwsMessageSignature,
+            })) as string
+        } catch (error) {
+            console.error('There was an error while decrypting the attestation data:', error)
+            return { isVerified: false, decryptedAttestationData: null }
+        }
+
+        const currentTimestamp = BigInt(Math.floor(Date.now() / 1000))
+        return { isVerified: currentTimestamp < attestation.data.expiry, decryptedAttestationData }
+    } catch (error) {
+        return { isVerified: false, decryptedAttestationData: null }
+    }
+}
+```
+
+Let's cover the differences between the existing `verifyAttestation` function and the updated one:
+
+- New function parameters:
+    - `authorizedSigner`: This parameter is expected to be one of the Credential's Authorized Signer keypairs we loaded from the keyfiles.
+    - `litDecryptionParams`: This object contains a Lit Node Client and an Ethereum wallet (we'll dive deeper into why we need an Ehtereum wallet later in this guide) which allows us to make the decryption request to the Lit network.
+- New function return type:
+    - `decryptedAttestationData`: This is the decrypted attestation data returned from the Lit Action after the SIWS message is authenticated and verified by the Lit network.
+- New return value type for `deserializeAttestationData`:
+    - Previously, this function call returned the raw attestation data that was stored on-chain, but now it's returning `AttestationEncryptionMetadata` (as defined in our [`types.ts` file](#creating-a-types-file)) which is our Lit encryption metadata: `ciphertext` and `dataToEncryptHash`.
+
+#### Diving into the Decryption Process
+
+As a prerequisite to making the decryption request to the Lit network, we need to create and sign a SIWS message with one of the Credential's Authorized Signer keypairs.
+
+##### Creating the SIWS Message
+
+Let's create the file `create-siws-message.ts` in our `lit` helpers directory, and export the function `createSiwsMessage`:
+
+```ts
+import { SiwsMessageForFormatting, SiwsMessageInput } from '../types'
+
+/**
+ * Creates a complete Siws message by filling in missing properties with sensible defaults
+ * @param siws - Siws message object with required address field
+ * @returns Complete Siws message with all fields populated
+ */
+export function createSiwsMessage(siws: SiwsMessageInput): SiwsMessageForFormatting {
+    const now = new Date()
+    const expirationTime = new Date(now.getTime() + 10 * 60 * 1000) // 10 minutes
+
+    // Generate a proper nonce if not provided (minimum 8 characters, alphanumeric)
+    const generatedNonce = siws.nonce || Math.random().toString(36).substring(2, 12) // 10 character alphanumeric
+
+    // Merge siws with defaults, siws values take precedence
+    return {
+        domain: siws.domain || 'localhost',
+        address: siws.address,
+        statement: siws.statement || 'Sign this message to authenticate with Lit Protocol',
+        uri: siws.uri || 'http://localhost',
+        version: siws.version || '1',
+        chainId: siws.chainId || 'devnet', // Must be string as per Siws spec: mainnet, testnet, devnet, localnet, etc.
+        nonce: generatedNonce,
+        issuedAt: siws.issuedAt || now.toISOString(),
+        expirationTime: siws.expirationTime || expirationTime.toISOString(),
+        notBefore: siws.notBefore,
+        requestId: siws.requestId,
+        resources: siws.resources || [],
+    }
+}
+```
+
+_As with the rest of this guide, any imported custom types from the [`types.ts` file](#creating-a-types-file) we created previously._
+
+This helper function utilizes [Phantom's SIWS message specification](https://github.com/phantom/sign-in-with-solana/tree/main), and is used to prove the identity of a Credential signer to the Lit network. This SIWS message is part of the authorization process in our custom Lit Action that will gatekeep who is permitted to decrypt the attestation data.
+
+##### Signing the SIWS Message
+
+Going back to the `verifyAttestation` function, the next step after creating the SIWS message is to sign it with a Credential's Authorized Signer keypair. To do this we'll create the file `sign-siws-message.ts` in our `lit` helpers directory, and export the function `signSiwsMessage`:
+
+```ts
+import { ethers } from 'ethers'
+import { createSignableMessage, KeyPairSigner } from 'gill'
+
+import { SiwsMessageForFormatting } from '../types'
+import { formatSiwsMessage } from './format-siws-message'
+
+/**
+ * Signs a SIWS message using a Solana keypair signer
+ * @param siwsMessage - The formatted SIWS message to sign
+ * @param signer - The Solana KeyPairSigner from setupWallets
+ * @returns Base58-encoded signature
+ */
+export async function signSiwsMessage(siwsMessage: SiwsMessageForFormatting, signer: KeyPairSigner): Promise<string> {
+    try {
+        const message = createSignableMessage(new TextEncoder().encode(formatSiwsMessage(siwsMessage)))
+        const signedMessage = await signer.signMessages([message])
+        return ethers.utils.base58.encode(signedMessage[0][signer.address])
+    } catch (error) {
+        throw new Error(`Failed to sign SIWS message: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    }
+}
+```
+
+This utilizes a helper function, `formatSiwsMessage`, that makes sure our SIWS message object is properly formatted as defined in Phantom's SIWS message specification.
+
+##### Formatting the SIWS Message
+
+Create the file `format-siws-message.ts` in our `lit` helpers directory, and export the function `formatSiwsMessage`:
+
+```ts
+import { SiwsMessageForFormatting } from '../types'
+
+/**
+ * Formats Siws message according to the ABNF specification:
+ * https://github.com/phantom/sign-in-with-solana/blob/main/siws.md#abnf-message-format
+ *
+ * @param siws - Siws message with required domain and address fields
+ * @returns Formatted message string according to Siws ABNF specification
+ */
+export function formatSiwsMessage(siws: SiwsMessageForFormatting): string {
+    if (!siws.domain || !siws.address) {
+        throw new Error('Domain and address are required for Siws message construction')
+    }
+
+    // Start with the mandatory domain and address line
+    let message = `${siws.domain} wants you to sign in with your Solana account:\n${siws.address}`
+
+    // Add statement if provided (with double newline separator)
+    if (siws.statement) {
+        message += `\n\n${siws.statement}`
+    }
+
+    // Collect advanced fields in the correct order as per ABNF spec
+    const fields: string[] = []
+
+    if (siws.uri) {
+        fields.push(`URI: ${siws.uri}`)
+    }
+    if (siws.version) {
+        fields.push(`Version: ${siws.version}`)
+    }
+    if (siws.chainId) {
+        fields.push(`Chain ID: ${siws.chainId}`)
+    }
+    if (siws.nonce) {
+        fields.push(`Nonce: ${siws.nonce}`)
+    }
+    if (siws.issuedAt) {
+        fields.push(`Issued At: ${siws.issuedAt}`)
+    }
+    if (siws.expirationTime) {
+        fields.push(`Expiration Time: ${siws.expirationTime}`)
+    }
+    if (siws.notBefore) {
+        fields.push(`Not Before: ${siws.notBefore}`)
+    }
+    if (siws.requestId) {
+        fields.push(`Request ID: ${siws.requestId}`)
+    }
+    if (siws.resources && siws.resources.length > 0) {
+        fields.push(`Resources:`)
+        for (const resource of siws.resources) {
+            fields.push(`- ${resource}`)
+        }
+    }
+
+    // Add advanced fields if any exist (with double newline separator)
+    if (fields.length > 0) {
+        message += `\n\n${fields.join('\n')}`
+    }
+
+    return message
+}
+```
+
+##### Making the Decryption Request
+
+Lastly, back in the `verifyAttestation` function, we'll use the `decryptAttestationData` helper function to make the decryption request to the Lit network.
+
+Create the file `decrypt-attestation-data.ts` in our `lit` helpers directory, and export the function `decryptAttestationData`:
+
+```ts
+import { LitNodeClient } from '@lit-protocol/lit-node-client'
+import { generateAuthSig, createSiweMessage, LitAccessControlConditionResource, LitActionResource } from '@lit-protocol/auth-helpers'
+import { LIT_ABILITY } from '@lit-protocol/constants'
+import { ethers } from 'ethers'
+
+import { LitDecryptionResponse, SiwsMessageForFormatting } from '../types'
+import { litActionCode as litActionCodeDecrypt } from '../litActionDecrypt'
+
+export const decryptAttestationData = async ({
+    litNodeClient,
+    litPayerEthersWallet,
+    ciphertext,
+    dataToEncryptHash,
+    siwsMessage,
+    siwsMessageSignature,
+}: {
+    litNodeClient: LitNodeClient
+    litPayerEthersWallet: ethers.Wallet
+    ciphertext: string
+    dataToEncryptHash: string
+    siwsMessage: SiwsMessageForFormatting
+    siwsMessageSignature: string
+}) => {
+    try {
+        const response = await litNodeClient.executeJs({
+            code: litActionCodeDecrypt,
+            sessionSigs: await litNodeClient.getSessionSigs({
+                chain: 'ethereum',
+                expiration: new Date(Date.now() + 1000 * 60 * 10).toISOString(), // 10 minutes
+                resourceAbilityRequests: [
+                    {
+                        resource: new LitActionResource('*'),
+                        ability: LIT_ABILITY.LitActionExecution,
+                    },
+                    {
+                        resource: new LitAccessControlConditionResource('*'),
+                        ability: LIT_ABILITY.AccessControlConditionDecryption,
+                    },
+                ],
+                authNeededCallback: async ({ uri, expiration, resourceAbilityRequests }) => {
+                    const toSign = await createSiweMessage({
+                        uri,
+                        expiration,
+                        resources: resourceAbilityRequests,
+                        walletAddress: await litPayerEthersWallet.getAddress(),
+                        nonce: await litNodeClient.getLatestBlockhash(),
+                        litNodeClient,
+                    })
+
+                    return await generateAuthSig({
+                        signer: litPayerEthersWallet,
+                        toSign,
+                    })
+                },
+            }),
+            jsParams: {
+                siwsMessage: JSON.stringify(siwsMessage),
+                siwsMessageSignature,
+                ciphertext,
+                dataToEncryptHash,
+            },
+        })
+
+        const responseJSON = JSON.parse(response.response as string) as LitDecryptionResponse
+
+        if (!responseJSON.hasOwnProperty('success')) {
+            throw new Error(`Unexpected return value from Lit decryption request: ${response.response}`)
+        }
+
+        if (responseJSON.success === false) {
+            throw new Error(`Failed to decrypt attestation data: ${response.response}`)
+        }
+
+        return responseJSON.decryptedData
+    } catch (error) {
+        throw new Error(`An unexpected error occurred while decrypting the attestation data: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    }
+}
+```
+
+This functino is the main integration point for the Lit SDK, and it's responsible for setting up and executing the request to the Lit network to execute our custom Lit Action that authorizes decryption of the attestation data.
+
+For the input parameters for this function, we'll cover `litNodeClient` and `litPayerEthersWallet` in more detail later in this guide, and the remaining are as follows:
+
+- `ciphertext`: This is the encrypted attestation data that we'll be decrypting, and was obtained from the on-chain attestation data.
+- `dataToEncryptHash`: This is the hash of the data that was encrypted along with our Access Control Conditions, and was also obtained from the on-chain attestation data.
+- `siwsMessage`: This is the SIWS message that we [created previously](#creating-the-siws-message) and is used in the authorization process that validates the person making the decryption request is permitted to decrypt the attestation data.
+- `siwsMessageSignature`: This is the signature of the SIWS message that was [previously signed](#signing-the-siws-message) with one of the Credential's Authorized Signer keypairs.
+
+The `litNodeClient.executeJs` function is used to execute our custom Lit Action and takes several parameters:
+
+###### `code`
+
+```ts
+code: litActionCodeDecrypt,
+```
+
+This is the code for our custom Lit Action that will be executed on the Lit network. The code can be uploaded to IPFS and referenced here using it's IPFS CID, or the code can be provided as a string as we're doing in this guide.
+
+We setup and dive into the Lit Action code in the [Decryption Lit Action](#the-decryption-lit-action) section.
+
+###### `sessionSigs`
+
+```ts
+sessionSigs: await litNodeClient.getSessionSigs({
+    chain: "ethereum",
+    expiration: new Date(Date.now() + 1000 * 60 * 10).toISOString(), // 10 minutes
+    resourceAbilityRequests: [
+        {
+            resource: new LitActionResource("*"),
+            ability: LIT_ABILITY.LitActionExecution,
+        },
+        {
+            resource: new LitAccessControlConditionResource("*"),
+            ability: LIT_ABILITY.AccessControlConditionDecryption,
+        },
+    ],
+    authNeededCallback: async ({
+        uri,
+        expiration,
+        resourceAbilityRequests,
+    }) => {
+        const toSign = await createSiweMessage({
+            uri,
+            expiration,
+            resources: resourceAbilityRequests,
+            walletAddress: await litPayerEthersWallet.getAddress(),
+            nonce: await litNodeClient.getLatestBlockhash(),
+            litNodeClient,
+        });
+
+        return await generateAuthSig({
+            signer: litPayerEthersWallet,
+            toSign,
+        });
+    },
+}),
+```
+
+Similar to paying for gas when using a blockchain, payment is required when making requests to the Lit network that require execution by the Lit nodes e.g. decrypting data. Session Signatures are how your identity is proven to the Lit network so that payment for your request can be processed. Additionally, a Session can be restricited to only permit specific tasks such as executing Lit Actions and decrypting data, as done in this guide.
+
+Session Signatures are created by specifying what `resourceAbilityRequests` are permitted to be executed using the Session, and an authentication function given to `authNeededCallback` to prove your identity. In this guide we're signing a Sign-in-with-Ethereum message using an Ethereum wallet which we generate randomly everytime the script is run.
+
+For this guide, the identity of the person paying for the decryption request to the Lit network is irrelevant, as we're using the Lit Datil-dev network which doesn't actually charge for usage of the network, however we're still required to authenticate with the Lit network via a Session.
+
+If you'd like to transition this guide to use the Lit Datil-test or mainnet, you'll need to learn about [paying for usage of the Lit network](https://developer.litprotocol.com/paying-for-lit/overview).
+
+You can also learn more about how Session Signatures work, how to generate and customize them [here](https://developer.litprotocol.com/sdk/authentication/session-sigs/intro).
+
+###### `jsParams`
+
+```ts
+jsParams: {
+  siwsMessage: JSON.stringify(siwsMessage),
+  siwsMessageSignature,
+  ciphertext,
+  dataToEncryptHash,
+},
+```
+
+The `jsParams` is an object or parameters that will be injected into the Lit Action runtime as global variables. So the keys of this object will be the variable names, and the object values will be the values of the parameters as defined here.
+
+Our custom Lit Action requires the raw SIWS message, the signature of the SIWS message, and the Lit encryption metadata in order to perform the authorization checks and decrypt the attestation data.
+
+##### The Decryption Lit Action
+
+Create the file `litActionDecrypt.ts` outside of the `lit` helpers directory (put the file in the same directory as the `attestation-demo.ts` file), and copy and paste the following code:
+
+```ts
+// @ts-nocheck
+
+const _litActionCode = async () => {
+    // Hardcoded values for this specific attestation service instance
+    const AUTHORIZED_RPC_URL = 'https://api.devnet.solana.com'
+    const AUTHORIZED_PROGRAM_ID = '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG'
+    const AUTHORIZED_CREDENTIAL_PDA = '4MZk467hXkFjzWeog1SizZutKqKVTkbwvVKswap2QKeW'
+
+    async function fetchAccountData(rpcUrl, address) {
+        try {
+            const response = await fetch(rpcUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'getAccountInfo',
+                    params: [address, { encoding: 'base64', commitment: 'confirmed' }],
+                }),
+            })
+
+            const data = await response.json()
+            if (data.error) {
+                throw new Error(`RPC error: ${data.error.message}`)
+            }
+
+            if (!data.result || !data.result.value) {
+                throw new Error('Account not found')
+            }
+
+            const accountInfo = data.result.value
+            return {
+                data: ethers.utils.base64.decode(accountInfo.data[0]),
+                owner: accountInfo.owner,
+            }
+        } catch (error) {
+            console.error('Error fetching account data:', error)
+            throw error
+        }
+    }
+
+    function parseCredentialAccount(data) {
+        let offset = 0
+
+        // Skip discriminator (1 byte)
+        offset += 1
+
+        // Read authority (32 bytes)
+        const authority = ethers.utils.base58.encode(data.slice(offset, offset + 32))
+        offset += 32
+
+        // Read name length (4 bytes, little-endian)
+        const nameLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
+        offset += 4
+
+        // Skip name bytes
+        offset += nameLength
+
+        // Read authorized signers length (4 bytes, little-endian)
+        const signersLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
+        offset += 4
+
+        // Read authorized signers
+        const authorizedSigners = []
+        for (let i = 0; i < signersLength; i++) {
+            const signer = ethers.utils.base58.encode(data.slice(offset, offset + 32))
+            authorizedSigners.push(signer)
+            offset += 32
+        }
+
+        return { authority, authorizedSigners }
+    }
+
+    function getSiwsMessage(siwsInput) {
+        console.log('Attempting to parse SIWS message: ', siwsInput)
+
+        if (!siwsInput.domain || !siwsInput.address) {
+            throw new Error('Domain and address are required for Siws message construction')
+        }
+
+        // Start with the mandatory domain and address line
+        let message = `${siwsInput.domain} wants you to sign in with your Solana account:\n${siwsInput.address}`
+
+        // Add statement if provided (with double newline separator)
+        if (siwsInput.statement) {
+            message += `\n\n${siwsInput.statement}`
+        }
+
+        // Collect advanced fields in the correct order as per ABNF spec
+        const fields = []
+
+        if (siwsInput.uri) {
+            fields.push(`URI: ${siwsInput.uri}`)
+        }
+        if (siwsInput.version) {
+            fields.push(`Version: ${siwsInput.version}`)
+        }
+        if (siwsInput.chainId) {
+            fields.push(`Chain ID: ${siwsInput.chainId}`)
+        }
+        if (siwsInput.nonce) {
+            fields.push(`Nonce: ${siwsInput.nonce}`)
+        }
+        if (siwsInput.issuedAt) {
+            fields.push(`Issued At: ${siwsInput.issuedAt}`)
+        }
+        if (siwsInput.expirationTime) {
+            fields.push(`Expiration Time: ${siwsInput.expirationTime}`)
+        }
+        if (siwsInput.notBefore) {
+            fields.push(`Not Before: ${siwsInput.notBefore}`)
+        }
+        if (siwsInput.requestId) {
+            fields.push(`Request ID: ${siwsInput.requestId}`)
+        }
+        if (siwsInput.resources && siwsInput.resources.length > 0) {
+            fields.push(`Resources:`)
+            for (const resource of siwsInput.resources) {
+                fields.push(`- ${resource}`)
+            }
+        }
+
+        // Add advanced fields if any exist (with double newline separator)
+        if (fields.length > 0) {
+            message += `\n\n${fields.join('\n')}`
+        }
+
+        return message
+    }
+
+    function validateSiwsMessage(siwsInput) {
+        const now = new Date()
+
+        // Check if message has expired (expirationTime is in the past)
+        if (siwsInput.expirationTime) {
+            const expirationTime = new Date(siwsInput.expirationTime)
+            if (now > expirationTime) {
+                return {
+                    valid: false,
+                    error: `SIWS message has expired. Current time: ${now.toISOString()}, Expiration: ${siwsInput.expirationTime}`,
+                }
+            }
+        }
+
+        // Check if message is not yet valid (notBefore is in the future)
+        if (siwsInput.notBefore) {
+            const notBefore = new Date(siwsInput.notBefore)
+            if (now < notBefore) {
+                return {
+                    valid: false,
+                    error: `SIWS message is not yet valid. Current time: ${now.toISOString()}, Not Before: ${siwsInput.notBefore}`,
+                }
+            }
+        }
+
+        return { valid: true }
+    }
+
+    async function verifySiwsSignature(siwsMessage, signerAddress, siwsMessageSignature) {
+        try {
+            const publicKey = await crypto.subtle.importKey(
+                'raw',
+                ethers.utils.base58.decode(signerAddress),
+                {
+                    name: 'Ed25519',
+                    namedCurve: 'Ed25519',
+                },
+                false,
+                ['verify']
+            )
+
+            const isValid = await crypto.subtle.verify(
+                'Ed25519',
+                publicKey,
+                ethers.utils.base58.decode(siwsMessageSignature),
+                new TextEncoder().encode(siwsMessage)
+            )
+
+            return isValid
+        } catch (error) {
+            console.error('Error in verifySiwsSignature:', error)
+            throw error
+        }
+    }
+
+    const siwsMessageJson = JSON.parse(siwsMessage)
+    const siwsMessageString = getSiwsMessage(siwsMessageJson)
+
+    try {
+        const siwsMessageValid = validateSiwsMessage(siwsMessageJson)
+        if (!siwsMessageValid.valid) {
+            console.log('SIWS message validation failed:', siwsMessageValid.error)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'SIWS message validation failed.',
+                    error: siwsMessageValid.error,
+                }),
+            })
+        }
+    } catch (error) {
+        console.error('Error in validateSiwsMessage:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error in validateSiwsMessage.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    try {
+        const siwsSignatureValid = await verifySiwsSignature(siwsMessageString, siwsMessageJson.address, siwsMessageSignature)
+
+        if (!siwsSignatureValid) {
+            console.log('Signature is invalid.')
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Signature is invalid.',
+                }),
+            })
+        }
+
+        console.log('Signature is valid.')
+    } catch (error) {
+        console.error('Error verifying signature:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error verifying signature.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // Fetch and verify authorized signers from the hardcoded credential
+    try {
+        const accountInfo = await fetchAccountData(AUTHORIZED_RPC_URL, AUTHORIZED_CREDENTIAL_PDA)
+
+        // Verify the credential account is owned by the correct program
+        if (accountInfo.owner !== AUTHORIZED_PROGRAM_ID) {
+            console.log(`Credential PDA owner mismatch. Expected: ${AUTHORIZED_PROGRAM_ID}, Got: ${accountInfo.owner}`)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Credential PDA is not owned by the authorized program',
+                    expectedOwner: AUTHORIZED_PROGRAM_ID,
+                    actualOwner: accountInfo.owner,
+                }),
+            })
+        }
+
+        const credential = parseCredentialAccount(accountInfo.data)
+
+        // Check if the signer is authorized
+        const signerAddress = siwsMessageJson.address
+        if (!credential.authorizedSigners.includes(signerAddress)) {
+            console.log(`Signer ${signerAddress} is not in authorized signers list`)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Signer is not authorized to decrypt',
+                    authorizedSigners: credential.authorizedSigners,
+                    requestingSigner: signerAddress,
+                }),
+            })
+        }
+
+        console.log(`Signer ${signerAddress} is authorized to decrypt`)
+    } catch (error) {
+        console.error('Error checking authorized signers:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error checking authorized signers',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    try {
+        const decryptedData = await Lit.Actions.decryptAndCombine({
+            accessControlConditions: [
+                {
+                    method: '',
+                    params: [':currentActionIpfsId'],
+                    pdaParams: [],
+                    pdaInterface: { offset: 0, fields: {} },
+                    pdaKey: '',
+                    chain: 'solana',
+                    returnValueTest: {
+                        key: '',
+                        comparator: '=',
+                        value: LitAuth.actionIpfsIds[0],
+                    },
+                },
+            ],
+            ciphertext,
+            dataToEncryptHash,
+            authSig: {
+                sig: ethers.utils.hexlify(ethers.utils.base58.decode(siwsMessageSignature)).slice(2),
+                derivedVia: 'solana.signMessage',
+                signedMessage: siwsMessageString,
+                address: siwsMessageJson.address,
+            },
+            chain: 'solana',
+        })
+        return LitActions.setResponse({ response: JSON.stringify({ success: true, decryptedData }) })
+    } catch (error) {
+        console.error('Error decrypting data:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error decrypting data.',
+                error: error.toString(),
+            }),
+        })
+    }
+}
+
+export const litActionCode = `(${_litActionCode.toString()})()`
+```

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -126,6 +126,20 @@ export default defineConfig({
                         {
                             text: "Tokenized Attestations",
                             link: "/guides/ts/tokenized-attestations"
+                        },
+                        {
+                            text: "Encrypted Attestation Data",
+                            collapsed: false,
+                            items: [
+                                {
+                                    text: "Basic Attestation Flow",
+                                    link: "/guides/ts/lit-encrypted-attestations/basic-attestation-flow"
+                                },
+                                {
+                                    text: "Tokenized Attestations",
+                                    link: "/guides/ts/lit-encrypted-attestations/tokenized-attestation-flow"
+                                }
+                            ]
                         }
                     ]
                 },


### PR DESCRIPTION
This PR creates two doc pages that walk through extending the existing SAS guides to utilize Lit for encrypting the attestation data.

To run the doc site:

1. `git clone git@github.com:solana-foundation/solana-attestation-site.git`
2. `pnpm i`
3. `pnpm docs:dev`
4. Navigate to: `http://localhost:5173/docs/guides/ts/lit-encrypted-attestations/basic-attestation-flow`

The second doc page is WIP