### PR TITLE
Init the Encrypted Basic and Tokenized Doc pages

### DIFF
--- a/docs/pages/guides/ts/lit-encrypted-attestations/basic-attestation-flow.mdx
+++ b/docs/pages/guides/ts/lit-encrypted-attestations/basic-attestation-flow.mdx
@@ -203,6 +203,8 @@ yarn add \
 yarn add -D @lit-protocol/types
 ```
 
+:::
+
 Within your existing `solana-attestation-demo` directory, create a `lit` directory we can use to store our Lit related files:
 
 ```bash
@@ -464,7 +466,7 @@ To run this helper script, we'll add a new script to our `package.json` file:
 
 ```json
 "scripts": {
-  "generate-credential-pda": "ts-node src/lit/generate-credential-pda.ts",
+  "generate-credential-pda": "ts-node generate-credential-pda.ts",
 }
 ```
 
@@ -653,7 +655,7 @@ export function createSiwsMessage(siws: SiwsMessageInput): SiwsMessageForFormatt
 }
 ```
 
-_As with the rest of this guide, any imported custom types from the [`types.ts` file](#creating-a-types-file) we created previously._
+_As with the rest of this guide, any imported custom types are defined in the [`types.ts` file](#creating-a-types-file) we created previously._
 
 This helper function utilizes [Phantom's SIWS message specification](https://github.com/phantom/sign-in-with-solana/tree/main), and is used to prove the identity of a Credential signer to the Lit network. This SIWS message is part of the authorization process in our custom Lit Action that will gatekeep who is permitted to decrypt the attestation data.
 
@@ -844,7 +846,7 @@ export const decryptAttestationData = async ({
 }
 ```
 
-This functino is the main integration point for the Lit SDK, and it's responsible for setting up and executing the request to the Lit network to execute our custom Lit Action that authorizes decryption of the attestation data.
+This function is the main integration point for the Lit SDK, and it's responsible for setting up and executing the request to the Lit network to execute our custom Lit Action that authorizes decryption of the attestation data.
 
 For the input parameters for this function, we'll cover `litNodeClient` and `litPayerEthersWallet` in more detail later in this guide, and the remaining are as follows:
 
@@ -909,9 +911,7 @@ Session Signatures are created by specifying what `resourceAbilityRequests` are 
 
 For this guide, the identity of the person paying for the decryption request to the Lit network is irrelevant, as we're using the Lit Datil-dev network which doesn't actually charge for usage of the network, however we're still required to authenticate with the Lit network via a Session.
 
-If you'd like to transition this guide to use the Lit Datil-test or mainnet, you'll need to learn about [paying for usage of the Lit network](https://developer.litprotocol.com/paying-for-lit/overview).
-
-You can also learn more about how Session Signatures work, how to generate and customize them [here](https://developer.litprotocol.com/sdk/authentication/session-sigs/intro).
+If you'd like to transition this guide to use the Lit Datil-test or mainnet, you'll need to learn about [paying for usage of the Lit network](https://developer.litprotocol.com/paying-for-lit/overview). You can also learn more about how Session Signatures work, and how to customize them [here](https://developer.litprotocol.com/sdk/authentication/session-sigs/intro).
 
 ###### `jsParams`
 
@@ -932,6 +932,8 @@ Our custom Lit Action requires the raw SIWS message, the signature of the SIWS m
 
 Create the file `litActionDecrypt.ts` outside of the `lit` helpers directory (put the file in the same directory as the `attestation-demo.ts` file), and copy and paste the following code:
 
+:::details[Below we'll be diving into the Lit Action code, piece by piece, but click here to view the complete Lit Action Code.]
+
 ```ts
 // @ts-nocheck
 
@@ -939,7 +941,7 @@ const _litActionCode = async () => {
     // Hardcoded values for this specific attestation service instance
     const AUTHORIZED_RPC_URL = 'https://api.devnet.solana.com'
     const AUTHORIZED_PROGRAM_ID = '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG'
-    const AUTHORIZED_CREDENTIAL_PDA = '4MZk467hXkFjzWeog1SizZutKqKVTkbwvVKswap2QKeW'
+    const AUTHORIZED_CREDENTIAL_PDA = 'Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk'
 
     async function fetchAccountData(rpcUrl, address) {
         try {
@@ -1256,3 +1258,977 @@ const _litActionCode = async () => {
 
 export const litActionCode = `(${_litActionCode.toString()})()`
 ```
+
+:::
+
+##### The Structure of the Lit Action Code
+
+When providing the Lit Action code to the Lit SDK, you'll need to provide it as a stringified self executing function which looks like this:
+
+```ts
+const _litActionCode = async () => {
+    // Lit Action code...
+}
+
+export const litActionCode = `(${_litActionCode.toString()})()`
+```
+
+The `litActionCode` is the stringified self executing function, and what we imported and provide to the Lit SDK as the [code](#code) parameter to the `litNodeClient.executeJs` call.
+
+##### Hardcoded Solana Constants
+
+```ts
+const _litActionCode = async () => {
+    // Hardcoded values for this specific attestation service instance
+    const AUTHORIZED_RPC_URL = 'https://api.devnet.solana.com'
+    const AUTHORIZED_PROGRAM_ID = '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG'
+    const AUTHORIZED_CREDENTIAL_PDA = 'Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk'
+
+    // The rest of the Lit Action code...
+}
+```
+
+- The `AUTHORIZED_RPC_URL` is the RPC URL of the Solana cluster that the attestation service is running on.
+- The `AUTHORIZED_PROGRAM_ID` is the program ID of the attestation service.
+- The `AUTHORIZED_CREDENTIAL_PDA` is the Credential PDA that was derived from the Issuer keypair.
+    - This PDA is unique to your Issuer keypair and is used to identify whether the requestor of the decryption request is authorized to decrypt the attestation data.
+    - We generated this PDA earlier in the [Running the Generate Credential PDA Script](#running-the-generate-credential-pda-script) section:
+        ```bash
+        2. Creating Credential...
+        Credential PDA: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
+        ```
+
+##### Fetching Account Data
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    async function fetchAccountData(rpcUrl, address) {
+        try {
+            const response = await fetch(rpcUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'getAccountInfo',
+                    params: [address, { encoding: 'base64', commitment: 'confirmed' }],
+                }),
+            })
+
+            const data = await response.json()
+            if (data.error) {
+                throw new Error(`RPC error: ${data.error.message}`)
+            }
+
+            if (!data.result || !data.result.value) {
+                throw new Error('Account not found')
+            }
+
+            const accountInfo = data.result.value
+            return {
+                data: ethers.utils.base64.decode(accountInfo.data[0]),
+                owner: accountInfo.owner,
+            }
+        } catch (error) {
+            console.error('Error fetching account data:', error)
+            throw error
+        }
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `fetchAccountData` function is a utility method that allows the Lit Action to query Solana's blockchain state directly from within the secure execution environment. It fetches and decodes account data from Solana using the `getAccountInfo` RPC call, handling errors, and returning both the account's data and owner. This will enable the Lit Action to check which signers are authorized to decrypt the attestation later in the code.
+
+##### Parsing the Credential Account Data
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    function parseCredentialAccount(data) {
+        let offset = 0
+
+        // Skip discriminator (1 byte)
+        offset += 1
+
+        // Read authority (32 bytes)
+        const authority = ethers.utils.base58.encode(data.slice(offset, offset + 32))
+        offset += 32
+
+        // Read name length (4 bytes, little-endian)
+        const nameLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
+        offset += 4
+
+        // Skip name bytes
+        offset += nameLength
+
+        // Read authorized signers length (4 bytes, little-endian)
+        const signersLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
+        offset += 4
+
+        // Read authorized signers
+        const authorizedSigners = []
+        for (let i = 0; i < signersLength; i++) {
+            const signer = ethers.utils.base58.encode(data.slice(offset, offset + 32))
+            authorizedSigners.push(signer)
+            offset += 32
+        }
+
+        return { authority, authorizedSigners }
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `parseCredentialAccount` function deserializes the raw bytes returned from the Solana RPC into a readable credential account structure. It manually parses the binary data by reading specific byte offsets that correspond to the on-chain account layout: skipping the discriminator, extracting the authority public key, reading the name length and skipping those bytes, then finally extracting the list of authorized signers. This parsing is necessary because Solana stores account data as raw bytes, and we need to extract the authorized signers list to verify if the requesting signer has permission to decrypt the attestation data.
+
+##### Recreating the SIWS Message
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    function getSiwsMessage(siwsInput) {
+        console.log('Attempting to parse SIWS message: ', siwsInput)
+
+        if (!siwsInput.domain || !siwsInput.address) {
+            throw new Error('Domain and address are required for Siws message construction')
+        }
+
+        // Start with the mandatory domain and address line
+        let message = `${siwsInput.domain} wants you to sign in with your Solana account:\n${siwsInput.address}`
+
+        // Add statement if provided (with double newline separator)
+        if (siwsInput.statement) {
+            message += `\n\n${siwsInput.statement}`
+        }
+
+        // Collect advanced fields in the correct order as per ABNF spec
+        const fields = []
+
+        if (siwsInput.uri) {
+            fields.push(`URI: ${siwsInput.uri}`)
+        }
+        if (siwsInput.version) {
+            fields.push(`Version: ${siwsInput.version}`)
+        }
+        if (siwsInput.chainId) {
+            fields.push(`Chain ID: ${siwsInput.chainId}`)
+        }
+        if (siwsInput.nonce) {
+            fields.push(`Nonce: ${siwsInput.nonce}`)
+        }
+        if (siwsInput.issuedAt) {
+            fields.push(`Issued At: ${siwsInput.issuedAt}`)
+        }
+        if (siwsInput.expirationTime) {
+            fields.push(`Expiration Time: ${siwsInput.expirationTime}`)
+        }
+        if (siwsInput.notBefore) {
+            fields.push(`Not Before: ${siwsInput.notBefore}`)
+        }
+        if (siwsInput.requestId) {
+            fields.push(`Request ID: ${siwsInput.requestId}`)
+        }
+        if (siwsInput.resources && siwsInput.resources.length > 0) {
+            fields.push(`Resources:`)
+            for (const resource of siwsInput.resources) {
+                fields.push(`- ${resource}`)
+            }
+        }
+
+        // Add advanced fields if any exist (with double newline separator)
+        if (fields.length > 0) {
+            message += `\n\n${fields.join('\n')}`
+        }
+
+        return message
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `getSiwsMessage` function reconstructs the SIWS message string from the JSON input provided as `siwsMessage` in the [`jsParams` Lit Action parameter](#jsparams) within the secure Lit Action environment. This reconstruction is a critical security step that avoids trusting the message string passed as input (which could be manipulated), and instead rebuilds the message from its individual components according to Phantom's SIWS specification. This ensures the message structure matches what was originally signed by the user.
+
+##### Validating the SIWS Message
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    function validateSiwsMessage(siwsInput) {
+        const now = new Date()
+
+        // Check if message has expired (expirationTime is in the past)
+        if (siwsInput.expirationTime) {
+            const expirationTime = new Date(siwsInput.expirationTime)
+            if (now > expirationTime) {
+                return {
+                    valid: false,
+                    error: `SIWS message has expired. Current time: ${now.toISOString()}, Expiration: ${siwsInput.expirationTime}`,
+                }
+            }
+        }
+
+        // Check if message is not yet valid (notBefore is in the future)
+        if (siwsInput.notBefore) {
+            const notBefore = new Date(siwsInput.notBefore)
+            if (now < notBefore) {
+                return {
+                    valid: false,
+                    error: `SIWS message is not yet valid. Current time: ${now.toISOString()}, Not Before: ${siwsInput.notBefore}`,
+                }
+            }
+        }
+
+        return { valid: true }
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `validateSiwsMessage` function performs time-based validation on the SIWS message to prevent replay attacks and ensure the authentication request is fresh. It checks two optional time constraints: the `expirationTime` field to ensure the message hasn't expired, and the `notBefore` field to ensure the message isn't being used before its intended validity period.
+
+##### Verifying the SIWS Signature
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    async function verifySiwsSignature(siwsMessage, signerAddress, siwsMessageSignature) {
+        try {
+            const publicKey = await crypto.subtle.importKey(
+                'raw',
+                ethers.utils.base58.decode(signerAddress),
+                {
+                    name: 'Ed25519',
+                    namedCurve: 'Ed25519',
+                },
+                false,
+                ['verify']
+            )
+
+            const isValid = await crypto.subtle.verify(
+                'Ed25519',
+                publicKey,
+                ethers.utils.base58.decode(siwsMessageSignature),
+                new TextEncoder().encode(siwsMessage)
+            )
+
+            return isValid
+        } catch (error) {
+            console.error('Error in verifySiwsSignature:', error)
+            throw error
+        }
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `verifySiwsSignature` function performs cryptographic verification to confirm the SIWS message was actually signed by the claimed wallet address. It uses the Web Crypto API to import the public key from the Solana address (converting from Base58 format), then verifies the Ed25519 signature against the reconstructed message string. This cryptographic proof ensures that only someone with the private key corresponding to the claimed address could have created the signature, preventing impersonation attacks where malicious users might try to claim they control a wallet they don't actually own.
+
+##### Putting It All Together
+
+Now that we've covered the individual functions that make up the Lit Action code, let's put it all together to perform the SIWS message validation, and check if the message signer is authorized to decrypt the attestation data.
+
+The first steps is to parse the SIWS message into a JSON object, and reconstruct the SIWS message from the input parameters: `siwsMessage` to ensure the message is valid and not expired, or being used before its intended validity period:
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    const siwsMessageJson = JSON.parse(siwsMessage)
+    const siwsMessageString = getSiwsMessage(siwsMessageJson)
+
+    try {
+        const siwsMessageValid = validateSiwsMessage(siwsMessageJson)
+        if (!siwsMessageValid.valid) {
+            console.log('SIWS message validation failed:', siwsMessageValid.error)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'SIWS message validation failed.',
+                    error: siwsMessageValid.error,
+                }),
+            })
+        }
+    } catch (error) {
+        console.error('Error in validateSiwsMessage:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error in validateSiwsMessage.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+Next, we'll verify the SIWS signature to ensure the message was actually signed by the claimed wallet address:
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    try {
+        const siwsSignatureValid = await verifySiwsSignature(siwsMessageString, siwsMessageJson.address, siwsMessageSignature)
+
+        if (!siwsSignatureValid) {
+            console.log('Signature is invalid.')
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Signature is invalid.',
+                }),
+            })
+        }
+
+        console.log('Signature is valid.')
+    } catch (error) {
+        console.error('Error verifying signature:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error verifying signature.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+Then we perform the authorization check by fetching the hardcoded Credential account from Solana to verify decryption permissions. This involves a multi-step security validation:
+
+1. We confirm the credential account is owned by the legitimate Solana Attestation Service program (preventing attacks using fake credential accounts).
+2. We parse the account data to extract the authorized signers list.
+3. We verify that the authenticated wallet address from our SIWS message is actually included in this list of permitted decryption signers.
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    // Fetch and verify authorized signers from the hardcoded credential
+    try {
+        const accountInfo = await fetchAccountData(AUTHORIZED_RPC_URL, AUTHORIZED_CREDENTIAL_PDA)
+
+        // Verify the credential account is owned by the correct program
+        if (accountInfo.owner !== AUTHORIZED_PROGRAM_ID) {
+            console.log(`Credential PDA owner mismatch. Expected: ${AUTHORIZED_PROGRAM_ID}, Got: ${accountInfo.owner}`)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Credential PDA is not owned by the authorized program',
+                    expectedOwner: AUTHORIZED_PROGRAM_ID,
+                    actualOwner: accountInfo.owner,
+                }),
+            })
+        }
+
+        const credential = parseCredentialAccount(accountInfo.data)
+
+        // Check if the signer is authorized
+        const signerAddress = siwsMessageJson.address
+        if (!credential.authorizedSigners.includes(signerAddress)) {
+            console.log(`Signer ${signerAddress} is not in authorized signers list`)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Signer is not authorized to decrypt',
+                    authorizedSigners: credential.authorizedSigners,
+                    requestingSigner: signerAddress,
+                }),
+            })
+        }
+
+        console.log(`Signer ${signerAddress} is authorized to decrypt`)
+    } catch (error) {
+        console.error('Error checking authorized signers:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error checking authorized signers',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+Lastly, after validating the signer of the SIWS message is authorized to decrypt the attestation data, we can proceed to decrypt the attestation data using `Lit.Actions.decryptAndCombine`:
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    try {
+        const decryptedData = await Lit.Actions.decryptAndCombine({
+            accessControlConditions: [
+                {
+                    method: '',
+                    params: [':currentActionIpfsId'],
+                    pdaParams: [],
+                    pdaInterface: { offset: 0, fields: {} },
+                    pdaKey: '',
+                    chain: 'solana',
+                    returnValueTest: {
+                        key: '',
+                        comparator: '=',
+                        value: LitAuth.actionIpfsIds[0],
+                    },
+                },
+            ],
+            ciphertext,
+            dataToEncryptHash,
+            authSig: {
+                sig: ethers.utils.hexlify(ethers.utils.base58.decode(siwsMessageSignature)).slice(2),
+                derivedVia: 'solana.signMessage',
+                signedMessage: siwsMessageString,
+                address: siwsMessageJson.address,
+            },
+            chain: 'solana',
+        })
+        return LitActions.setResponse({ response: JSON.stringify({ success: true, decryptedData }) })
+    } catch (error) {
+        console.error('Error decrypting data:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error decrypting data.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `Lit.Actions.decryptAndCombine` function is part of the Lit Actions SDK and is available globally within the Lit node execution environment. When invoked, it initiates the distributed decryption process across the Lit network. Each participating Lit node checks whether the provided Access Control Conditions are satisfied, and if so, generates and shares its decryption share with the network. Once enough valid shares are collected (2/3 of the total Lit nodes), they are combined to reconstruct the decrypted data, which is then returned to the Lit Action.
+
+The parameters for `Lit.Actions.decryptAndCombine` are:
+
+- `accessControlConditions`: An array of Access Control Conditions that must be satisfied for the decryption to occur.
+- `ciphertext`: The ciphertext to decrypt that we fetched from the on-chain Attestation account.
+- `dataToEncryptHash`: The hash of the data to encrypt that we fetched from the on-chain Attestation account.
+- `authSig`: The signature of the SIWS message used by the Lit nodes to authenticate who's making the decryption request.
+- `chain`: The chain corresponding to the `authSig` parameter (in this case, `solana` because we're providing a signature using a Solana keypair).
+
+For a refresher on how the `accessControlConditions` parameter works, check out the [Access Control Conditions](#access-control-conditions) section we covered earlier.
+
+## Implementation
+
+Now that we've setup and covered all the parts of this demo, let's run it!
+
+The following demonstation script follows the same pattern as the [Basic Attestation Flow](/guides/ts/lit-encrypted-attestations/basic-attestation-flow) guide, but with some changes that demonstrate how to use the helper functions we created above to encrypt the attestation data.
+
+### Prerequisites
+
+- As [mentioned earlier](#running-the-generate-credential-pda-script), make sure to run the `generate-credential-pda` script to create the Issuer and Authorized Signers keypairs, as well as derive the Credential PDA.
+- Copy and paste the Credential PDA from the output of the script into the `AUTHORIZED_CREDENTIAL_PDA` variable in Lit Action (see [here](#hardcoded-credential-account) for more details).
+
+### Step 1: Setup
+
+Now, let's build the main demonstration function that showcases the complete attestation workflow. Add the `main` function to your code--we'll use this to outline for our steps:
+
+```ts
+let _litNodeClient: LitNodeClient | null = null
+
+async function main() {
+    console.log('Starting Solana Attestation Service with Lit Protocol encrypted attestation demo\n')
+
+    const client: SolanaClient = createSolanaClient({ urlOrMoniker: CONFIG.CLUSTER_OR_RPC })
+
+    // Step 1: Setup wallets and fund payer
+    console.log('1. Setting up wallets and funding payer...')
+    const { payer, authorizedSigner1, authorizedSigner2, issuer, testUser } = await setupWallets(client)
+
+    // Step 2: Setting up Lit
+
+    // Step 3: Setting up Credential
+
+    // Step 4: Createing Schema
+
+    // Step 5: Creating Attestation
+
+    // Step 6: Updating Authorized Signers
+
+    // Step 7: Verifying Attestation
+
+    // Step 8: Closing Attestation
+}
+```
+
+The current code includes spaces for 8 steps. We've started by creating our client and calling our `setupWallets` function. Let's add the remaining steps next.
+
+### Step 2: Setting up Lit
+
+This step is creating our Lit node client, connecting us to the Lit Datil-dev network. Additionally, the Ethereum wallet we'll be using as the payer for the decryption request is generated and returned to us. Add the following code to your `main` function after Step 1:
+
+_Note: remeber that while using the Lit Datil-dev network, payment is actually required, but providing a wallet is still required._
+
+```ts
+// Step 2: Setup Lit
+console.log('2. Setting up Lit...')
+const { litNodeClient, litPayerEthersWallet } = await setupLit()
+_litNodeClient = litNodeClient
+```
+
+### Step 3: Setting up Credential
+
+Next we're going to create our Credential account if it doesn't already exist, or fetch the existing one if it does.
+
+Unlike the [Basic Attestation Flow](/guides/ts/lit-encrypted-attestations/basic-attestation-flow) guide that always creates a new Credential keypair and account every time you run the demo, this demo reuses the Issuer keypair so that we have a static Credential PDA to use in out Lit Action.
+
+Add the following code to your `main` function after Step 2:
+
+```ts
+// Step 3: Create Credential (if it doesn't exist)
+console.log('\n3. Setting up Credential...')
+const [credentialPda] = await deriveCredentialPda({
+    authority: issuer.address,
+    name: CONFIG.CREDENTIAL_NAME,
+})
+
+try {
+    // Check if credential already exists
+    const existingCredential = await fetchCredential(client.rpc, credentialPda)
+    console.log(`    - Credential already exists: ${credentialPda}`)
+    console.log(`    - Authority: ${existingCredential.data.authority}`)
+    console.log(`    - Authorized signers: ${existingCredential.data.authorizedSigners.length}`)
+} catch (error) {
+    // Credential doesn't exist, create it
+    console.log(`    - Creating new credential: ${credentialPda}`)
+    const createCredentialInstruction = getCreateCredentialInstruction({
+        payer,
+        credential: credentialPda,
+        authority: issuer,
+        name: CONFIG.CREDENTIAL_NAME,
+        signers: [authorizedSigner1.address],
+    })
+
+    await sendAndConfirmInstructions(client, payer, [createCredentialInstruction], 'Credential created')
+    console.log(`    - Credential created successfully`)
+}
+```
+
+### Step 4: Create Schema
+
+Next, we need to define our _Schema_ to define the structure of data that can be attested (`ciphertext` and `dataToEncryptHash` in our example).
+
+Just like the Credential PDA, we're going to check if the Schema PDA already exists, and create it if it doesn't.
+
+Add the following code to your `main` function after Step 3:
+
+```ts
+// Step 4: Create Schema
+console.log('\n4.  Creating Schema...')
+const [schemaPda] = await deriveSchemaPda({
+    credential: credentialPda,
+    name: CONFIG.SCHEMA_NAME,
+    version: CONFIG.SCHEMA_VERSION,
+})
+
+try {
+    // Check if schema already exists
+    const existingSchema = await fetchSchema(client.rpc, schemaPda)
+    console.log(`    - Schema already exists: ${schemaPda}`)
+    console.log(`    - Schema name: ${new TextDecoder().decode(existingSchema.data.name)}`)
+    console.log(`    - Version: ${existingSchema.data.version}`)
+} catch (error) {
+    // Schema doesn't exist, create it
+    console.log(`    - Creating new schema: ${schemaPda}`)
+    const createSchemaInstruction = getCreateSchemaInstruction({
+        authority: issuer,
+        payer,
+        name: CONFIG.SCHEMA_NAME,
+        credential: credentialPda,
+        description: CONFIG.SCHEMA_DESCRIPTION,
+        fieldNames: CONFIG.SCHEMA_FIELDS,
+        schema: schemaPda,
+        layout: CONFIG.SCHEMA_LAYOUT,
+    })
+
+    await sendAndConfirmInstructions(client, payer, [createSchemaInstruction], 'Schema created')
+    console.log(`    - Schema created successfully`)
+}
+```
+
+### Step 5: Create Attestation
+
+Next, we need to issue an actual attestation to a specific user with the defined data and expiration.
+
+Because we're encrypting our attestation data, we need to first encrypt it using our `encryptAttestationData` helper function, and then create the attestation using the encryption metadata.
+
+Add the following code to your `main` function after Step 4:
+
+```ts
+// Step 5: Create and Encrypt Attestation
+console.log('\n5. Creating Attestation...')
+const [attestationPda] = await deriveAttestationPda({
+    credential: credentialPda,
+    schema: schemaPda,
+    nonce: testUser.address,
+})
+
+const schema = await fetchSchema(client.rpc, schemaPda)
+const expiryTimestamp = Math.floor(Date.now() / 1000) + CONFIG.ATTESTATION_EXPIRY_DAYS * 24 * 60 * 60
+
+const attestationEncryptionMetadata = await encryptAttestationData({
+    attestationData: new TextEncoder().encode(JSON.stringify(CONFIG.ATTESTATION_DATA)),
+    litNodeClient,
+})
+
+const createAttestationInstruction = getCreateAttestationInstruction({
+    payer,
+    authority: authorizedSigner1,
+    credential: credentialPda,
+    schema: schemaPda,
+    attestation: attestationPda,
+    nonce: testUser.address,
+    expiry: expiryTimestamp,
+    data: serializeAttestationData(schema.data, {
+        ...attestationEncryptionMetadata,
+    }),
+})
+
+await sendAndConfirmInstructions(client, payer, [createAttestationInstruction], 'Attestation created')
+console.log(`    - Attestation PDA: ${attestationPda}`)
+```
+
+### Step 6: Update Authorized Signers
+
+Next, let's add `authorizedSigner2` as an authorized signer to our credential to demonstrate how to manage who can issue attestations for the credential.
+
+Add the following code to your `main` function after Step 5:
+
+```ts
+// Step 6: Update Authorized Signers
+console.log('\n6. Updating Authorized Signers...')
+const changeAuthSignersInstruction = getChangeAuthorizedSignersInstruction({
+    payer,
+    authority: issuer,
+    credential: credentialPda,
+    signers: [authorizedSigner1.address, authorizedSigner2.address],
+})
+
+await sendAndConfirmInstructions(client, payer, [changeAuthSignersInstruction], 'Authorized signers updated')
+```
+
+### Step 7: Verify Attestation
+
+Let's run a verification check to show how you might check if users have valid attestations, testing both attested and non-attested users. Normally, you might run something like this on your backend when a user signs into your platform.
+
+Add the following code to your `main` function after Step 6:
+
+```ts
+// Step 7: Verify Attestation
+console.log('\n7. Verifying Attestations...')
+
+const isUserVerified = await verifyAttestation({
+    client,
+    schemaPda,
+    userAddress: testUser.address,
+    authorizedSigner: authorizedSigner1, // Use one of the authorized signers
+    litDecryptionParams: {
+        litNodeClient,
+        litPayerEthersWallet,
+    },
+})
+console.log(`    - Test User is ${isUserVerified.isVerified ? 'verified' : 'not verified'}`)
+if (isUserVerified.decryptedAttestationData) {
+    console.log(`    - Decrypted Attestation Data: ${isUserVerified.decryptedAttestationData}`)
+}
+
+const randomUser = await generateKeyPairSigner()
+const isRandomVerified = await verifyAttestation({
+    client,
+    schemaPda,
+    userAddress: randomUser.address,
+    authorizedSigner: authorizedSigner2, // Use the other authorized signer
+    litDecryptionParams: {
+        litNodeClient,
+        litPayerEthersWallet,
+    },
+})
+console.log(`    - Random User is ${isRandomVerified.isVerified ? 'verified' : 'not verified'}`)
+
+// Test with unauthorized signer (should fail)
+console.log('\n    Testing with unauthorized signer (should fail)...')
+const unauthorizedSigner = await generateKeyPairSigner()
+console.log(`    - Unauthorized signer address: ${unauthorizedSigner.address}`)
+
+const unauthorizedResult = await verifyAttestation({
+    client,
+    schemaPda,
+    userAddress: testUser.address,
+    authorizedSigner: unauthorizedSigner, // This signer is NOT in the credential
+    litDecryptionParams: {
+        litNodeClient,
+        litPayerEthersWallet,
+    },
+})
+
+if (unauthorizedResult.isVerified) {
+    console.log(`    - ❌ Unauthorized signer is verified`)
+} else {
+    console.log(`    - ✅ Unauthorized signer is not verified`)
+}
+```
+
+### Step 8: Close Attestation
+
+Finally, let's revoke an attestation from a user, and return the summary data for pretty printing.
+
+Add the following code to your `main` function after Step 7:
+
+```ts
+console.log('\n8. Closing Attestation...')
+
+const eventAuthority = await deriveEventAuthorityAddress()
+const closeAttestationInstruction = getCloseAttestationInstruction({
+    payer,
+    attestation: attestationPda,
+    authority: authorizedSigner1,
+    credential: credentialPda,
+    eventAuthority,
+    attestationProgram: SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS,
+})
+await sendAndConfirmInstructions(client, payer, [closeAttestationInstruction], 'Closed attestation')
+
+// Return summary data for pretty printing
+return {
+    addresses: {
+        credentialPda,
+        schemaPda,
+        attestationPda,
+        testUserAddress: testUser.address,
+    },
+    verification: isUserVerified,
+    randomVerification: isRandomVerified,
+    unauthorizedResult,
+    config: CONFIG,
+    attestationEncryptionMetadata,
+}
+```
+
+### Calling the Main Function
+
+The following code calls the `main` function we've just finished defining, validates the results, and also handles the pretty printing of the results.
+
+Add the following code after your `main` function to execute it:
+
+```ts
+main()
+    .then(results => {
+        console.log('\n' + '='.repeat(80))
+        console.log('SOLANA ATTESTATION SERVICE WITH LIT PROTOCOL ENCRYPTED ATTESTATION DEMO')
+        console.log('='.repeat(80))
+
+        console.log('\n📋 DEMO CONFIGURATION:')
+        console.log(`   Network: ${results.config.CLUSTER_OR_RPC}`)
+        console.log(`   Organization: ${results.config.CREDENTIAL_NAME}`)
+        console.log(`   Schema: ${results.config.SCHEMA_NAME} (v${results.config.SCHEMA_VERSION})`)
+
+        console.log('\n🔑 CREATED ACCOUNTS:')
+        console.log(`   Credential PDA:    ${results.addresses.credentialPda}`)
+        console.log(`   Schema PDA:        ${results.addresses.schemaPda}`)
+        console.log(`   Attestation PDA:   ${results.addresses.attestationPda}`)
+        console.log(`   Test User:         ${results.addresses.testUserAddress}`)
+
+        console.log('\n🧪 VERIFICATION TEST RESULTS:')
+
+        // Test User Verification
+        const testUserStatus = results.verification.isVerified ? '✅ PASSED' : '❌ FAILED'
+        console.log(`   Test User Verification:     ${testUserStatus}`)
+        if (results.verification.isVerified) {
+            console.log(`   Encrypted Metadata:`)
+            console.log(`     - Ciphertext: ${results.attestationEncryptionMetadata.ciphertext.substring(0, 50)}...`)
+            console.log(`     - Data Hash: ${results.attestationEncryptionMetadata.dataToEncryptHash}`)
+            if (results.verification.decryptedAttestationData) {
+                console.log(`   Decrypted Attestation Data: ${results.verification.decryptedAttestationData}`)
+            }
+        }
+
+        // Random User Verification (should fail)
+        const randomUserStatus = !results.randomVerification.isVerified ? '✅ PASSED' : '❌ FAILED'
+        console.log(`   Random User Verification:   ${randomUserStatus} (correctly rejected)`)
+
+        // Unauthorized Signer Test (should fail)
+        const unauthorizedStatus = !results.unauthorizedResult.isVerified ? '✅ PASSED' : '❌ FAILED'
+        console.log(`   Unauthorized Signer Test:   ${unauthorizedStatus} (correctly rejected)`)
+
+        const allTestsPassed = results.verification.isVerified && !results.randomVerification.isVerified && !results.unauthorizedResult.isVerified
+
+        if (allTestsPassed) {
+            console.log('   ✅ ALL TESTS PASSED! Demo completed successfully.')
+        } else {
+            console.log('   ❌ Some tests failed. Please review the results above.')
+        }
+
+        console.log('\n' + '='.repeat(80))
+    })
+    .catch(error => {
+        console.error('\n❌ Demo failed:', error)
+        process.exit(1)
+    })
+    .finally(() => {
+        _litNodeClient?.disconnect()
+    })
+```
+
+## Running the Demonstration
+
+To test your attestation workflow, run the script in your project terminal:
+
+:::code-group
+
+```bash [npm]
+npm start
+```
+
+```bash [pnpm]
+pnpm start
+```
+
+```bash [yarn]
+yarn start
+```
+
+:::
+
+Here's what you should expect to see in the output:
+
+```
+lit-js-sdk:constants:errors deprecated LitErrorKind is deprecated and will be removed in a future version. Use LIT_ERROR_KIND instead. node:internal/modules/cjs/loader:1692:14
+Starting Solana Attestation Service with Lit Protocol encrypted attestation demo
+
+1. Setting up wallets and funding payer...
+authorized-signer-1 keypair does not exist at path: key-pairs/authorized-signer-1.keypair.json. Generating it...
+Got Authorized Signer 1 keypair with address: 8XMEduQLuEw4LHGD6a66LeH1TKJsa3rpghGnM1mjbHCN
+authorized-signer-2 keypair does not exist at path: key-pairs/authorized-signer-2.keypair.json. Generating it...
+Got Authorized Signer 2 keypair with address: 8BDVzsSvqFFMDpcqcueTBVnPu33aqP72XJq3QUfGAeho
+Got Issuer keypair with address: EFjEXBpSHL7xXUNZEQf5CKWD7dZHkLfqc1i9tceoqms2
+    - Airdrop completed: 5oZPNTNhkXZDvEeKFDrwhwym49QCn8pvPTfFfZHjhMA9CR8Me29fXuFx4cRWFRwnTM37j4sCEh7DhUaapaygQ72r
+2. Setting up Lit...
+lit-js-sdk:constants:constants deprecated LogLevel is deprecated and will be removed in a future version. Use LOG_LEVEL instead. node_modules/.pnpm/@lit-protocol+core@7.2.1_typescript@5.8.3/node_modules/@lit-protocol/core/src/lib/lit-core.js:453:119
+
+3. Setting up Credential...
+    - Creating new credential: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
+    - Credential created - Signature: 2LtJedSKv7bKcoSLKLQxt2Woio8r4cxkXdcvxmTAEY1B8Y5TRHuddtnkQwQm6Gu7WLLnJsP9ZL5XCvBL67KAW8SH
+    - Credential created successfully
+
+4.  Creating Schema...
+    - Creating new schema: 9Zhbp3ybaZGnPQH6LHuC6fE51qu33g1byan9X34XGcqa
+    - Schema created - Signature: 4Uu4oSh6dFQg81ryXQsYiPwWgGSqg7rNpRSogAo4g3EVmzL8Z6h8qABviPQVEoqUENRJgkfnbgm7ttrLTPb1GhnR
+    - Schema created successfully
+
+5. Creating Attestation...
+using deprecated parameters for `initSync()`; pass a single object instead
+    - Attestation created - Signature: 3KBcnS3FnH1ACn1hPhEhGB9aMDLRvr31fC5fizMEC1Qiz38WEGEXgWqMhsyqEJabYoHWe5scSaxeMcvtBTdXnh7b
+    - Attestation PDA: 5Baypg1tZ6M1wmBKw56b5YZ6RV7AyJtrsyD5kVSZ9q3C
+
+6. Updating Authorized Signers...
+    - Authorized signers updated - Signature: 5zCcr9A3Z6ag4pCNHi4BwaSDdvqjZStJWBu43RgidvYYSLSwsf5mPbRHjNo41caVfAdHEgWgJ52QFRuWjopZn8KK
+
+7. Verifying Attestations...
+    - Attestation data: {
+  ciphertext: 'mBWDUTwA+LHxmhAbFGO3H+wc24rshZZgynWblL6IFsUxvbuipA2goo5Ps66i/4sH5ecEb/G67AE/1KvxyvhvUZCpagAWMYZvR6gg7q/5tVQvfEV6mL6XD9e9U0u00izx6ILiMUVJU/tnt2FNVNU6aTQC8IS4PSPGx6KIE+iSC68C',
+  dataToEncryptHash: '4efa888818ad5ba81b0e459037eb8c62a3f0bdf401de5372e21d8aa132a0a808'
+}
+Storage key "lit-session-key" is missing. Not a problem. Continue...
+Storage key "lit-wallet-sig" is missing. Not a problem. Continue...
+Unable to store walletSig in local storage. Not a problem. Continue...
+    - Test User is verified
+    - Decrypted Attestation Data: {"name":"test-user","age":100,"country":"usa"}
+    - Random User is not verified
+
+    Testing with unauthorized signer (should fail)...
+    - Unauthorized signer address: EHG46v4pFgRwtrfteCds1sApEvSJWnnN7iFkUGcMERAF
+    - Attestation data: {
+  ciphertext: 'mBWDUTwA+LHxmhAbFGO3H+wc24rshZZgynWblL6IFsUxvbuipA2goo5Ps66i/4sH5ecEb/G67AE/1KvxyvhvUZCpagAWMYZvR6gg7q/5tVQvfEV6mL6XD9e9U0u00izx6ILiMUVJU/tnt2FNVNU6aTQC8IS4PSPGx6KIE+iSC68C',
+  dataToEncryptHash: '4efa888818ad5ba81b0e459037eb8c62a3f0bdf401de5372e21d8aa132a0a808'
+}
+Storage key "lit-session-key" is missing. Not a problem. Continue...
+Storage key "lit-wallet-sig" is missing. Not a problem. Continue...
+Unable to store walletSig in local storage. Not a problem. Continue...
+There was an error while decrypting the attestation data: Error: An unexpected error occurred while decrypting the attestation data: Failed to decrypt attestation data: {"success":false,"message":"Signer is not authorized to decrypt","authorizedSigners":["8XMEduQLuEw4LHGD6a66LeH1TKJsa3rpghGnM1mjbHCN","8BDVzsSvqFFMDpcqcueTBVnPu33aqP72XJq3QUfGAeho"],"requestingSigner":"EHG46v4pFgRwtrfteCds1sApEvSJWnnN7iFkUGcMERAF"}
+    at decryptAttestationData (lit/decrypt-attestation-data.ts:80:15)
+    at processTicksAndRejections (node:internal/process/task_queues:105:5)
+    at async verifyAttestation (attestation-demo.ts:149:40)
+    at async main (attestation-demo.ts:334:32)
+    - ✅ Unauthorized signer is not verified
+
+7. Closing Attestation...
+    - Closed attestation - Signature: b6NFkqmsLTeCeLoWJocx2n152vx5TcLehA9R4i3piZefeGroBzv91Lesdwdsn61N1MnF4L7ETPv7z9f2TUmDXwK
+
+================================================================================
+SOLANA ATTESTATION SERVICE WITH LIT PROTOCOL ENCRYPTED ATTESTATION DEMO
+================================================================================
+
+📋 DEMO CONFIGURATION:
+   Network: devnet
+   Organization: LIT-ENCRYPTED-ATTESTATIONS
+   Schema: LIT-ENCRYPTED-METADATA (v1)
+
+🔑 CREATED ACCOUNTS:
+   Credential PDA:    Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
+   Schema PDA:        9Zhbp3ybaZGnPQH6LHuC6fE51qu33g1byan9X34XGcqa
+   Attestation PDA:   5Baypg1tZ6M1wmBKw56b5YZ6RV7AyJtrsyD5kVSZ9q3C
+   Test User:         FgHoHpy589aV5y6dKymwZ1okJ8nL6p8x4eqotf7rMMfj
+
+🧪 VERIFICATION TEST RESULTS:
+   Test User Verification:     ✅ PASSED
+   Encrypted Metadata:
+     - Ciphertext: mBWDUTwA+LHxmhAbFGO3H+wc24rshZZgynWblL6IFsUxvbuipA...
+     - Data Hash: 4efa888818ad5ba81b0e459037eb8c62a3f0bdf401de5372e21d8aa132a0a808
+   Decrypted Attestation Data: {"name":"test-user","age":100,"country":"usa"}
+   Random User Verification:   ✅ PASSED (correctly rejected)
+   Unauthorized Signer Test:   ✅ PASSED (correctly rejected)
+   ✅ ALL TESTS PASSED! Demo completed successfully.
+
+================================================================================
+```
+
+The `lit-js-sdk` logs are expected, and can be ignored, and the `There was an error while decrypting the attestation data` error is for our decryption attempt using an unauthorized signer in [Step 7](#step-7-verify-attestation).
+
+If you see `✅ ALL TESTS PASSED! Demo completed successfully.`, you've successfully completed the demo!
+
+## Wrap Up
+
+Congratulations! You've successfully implemented a complete Solana Attestation Service system using Lit Protocol to encrypt the attestation data. You now have a working demonstration that shows how to:
+
+- **Create credentials** that represent issuing authorities
+- **Define schemas** for encrypted attestation metadata (`ciphertext` and `dataToEncryptHash`)
+- **Encrypt attestation data using Lit Protocol** with custom access control conditions
+- **Issue encrypted attestations** to specific users, storing only Lit encryption metadata on-chain
+- **Manage authorized signers** for enhanced security and dynamic access control
+- **Verify and decrypt attestations** programmatically, ensuring only authorized signers can access the underlying data
+- **Close (revoke) attestations** as needed
+
+The Solana Attestation Service provides a powerful foundation for building trust and identity systems on Solana. Whether you're creating compliance systems, financial credentials, professional certifications, or gaming achievements, SAS gives you the tools to issue and verify claims in a decentralized, transparent way.
+
+**Want to learn more?** Check out our [Guide: Encrypted Tokenized Attestations with Lit Protocol](/guides/ts/lit-encrypted-attestations/tokenized-attestation-flow).
+
+## Additional Resources
+
+- Need help? Ask questions the [Solana Stack Exchange](https://solana.stackexchange.com/) with a `SAS` tag.
+- [**SAS Source Code**](https://github.com/solana-foundation/solana-attestation-service)
+- [**Complete Code Example**](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript/attestation-flow-guides/src/lit/sas-standard-lit-demo.ts)
+- [**Solana Developer Resources**](https://solana.com/developers)
+- [**Lit Protocol Documentation**](https://developer.litprotocol.com/)
+- [**Lit Protocol Builders Telegram Group**](https://t.me/+aa73FAF9Vp82ZjJh)

--- a/docs/pages/guides/ts/lit-encrypted-attestations/basic-attestation-flow.mdx
+++ b/docs/pages/guides/ts/lit-encrypted-attestations/basic-attestation-flow.mdx
@@ -85,10 +85,10 @@ SOLANA ATTESTATION SERVICE WITH LIT PROTOCOL ENCRYPTED ATTESTATION DEMO
 Before starting this guide, you should have:
 
 - [**Node.js**](https://nodejs.org/en/download) (v22 or later)
-- [**Solana CLI**](https://solana.com/docs/intro/installation) v 2.2.x or greater
+- [**Solana CLI**](https://solana.com/docs/intro/installation) v2.2.x or greater
 - [TypeScript](http://typescriptlang.org/) Experience
 
-Additionally, this guide builds on top of the [Basic Solana Attestation Flow](/guides/ts/how-to-create-digital-credentials) guide, so you should have a working implementation of that guide to add to before starting this one.
+Additionally, this guide builds on top of the [Basic Solana Attestation Flow](/guides/ts/how-to-create-digital-credentials) guide, so you should have a working implementation of that guide before starting this one.
 
 ## Understanding Lit Encryption
 
@@ -170,7 +170,7 @@ When Lit encrypts your attestation data, it returns two crucial pieces of metada
 
 _Prefer to jump straight to the code? Check out our [Examples Repo on GitHub](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript/attestation-flow-guides/src/lit/sas-standard-lit-demo.ts) for the complete code for this guide\!_
 
-As mentioned above, this guide builds on top of the [Basic Solana Attestation Flow](/guides/ts/how-to-create-digital-credentials) guide, so make sure you have a working implementation of that guide to add to before continuing with this one.
+As mentioned above, this guide builds on top of the [Basic Solana Attestation Flow](/guides/ts/how-to-create-digital-credentials) guide, so make sure you have a working implementation of that guide before continuing with this one.
 
 Let's start by adding the necessary dependencies to encrypt our attestation data with Lit:
 
@@ -217,7 +217,7 @@ We'll cover each of the following types as we use them in this guide, but for no
 
 ```ts
 /**
- * Sign-in With Solana (Siws) messages (following Phantom's specification)
+ * Sign-in With Solana (SIWS) messages (following Phantom's specification)
  * https://github.com/phantom/sign-in-with-solana/tree/main
  */
 export interface SiwsMessage {
@@ -294,7 +294,7 @@ export interface SiwsMessage {
 }
 
 /**
- * Type-safe Siws message for formatting - requires mandatory fields domain and address
+ * Type-safe SIWS message for formatting - requires mandatory fields domain and address
  */
 export interface SiwsMessageForFormatting extends SiwsMessage {
     domain: string // Required for message construction
@@ -697,10 +697,10 @@ Create the file `format-siws-message.ts` in our `lit` helpers directory, and exp
 import { SiwsMessageForFormatting } from '../types'
 
 /**
- * Formats Siws message according to the ABNF specification:
+ * Formats SIWS message according to the ABNF specification:
  * https://github.com/phantom/sign-in-with-solana/blob/main/siws.md#abnf-message-format
  *
- * @param siws - Siws message with required domain and address fields
+ * @param siws - SIWS message with required domain and address fields
  * @returns Formatted message string according to Siws ABNF specification
  */
 export function formatSiwsMessage(siws: SiwsMessageForFormatting): string {
@@ -2220,7 +2220,7 @@ Congratulations! You've successfully implemented a complete Solana Attestation S
 - **Verify and decrypt attestations** programmatically, ensuring only authorized signers can access the underlying data
 - **Close (revoke) attestations** as needed
 
-The Solana Attestation Service provides a powerful foundation for building trust and identity systems on Solana. Whether you're creating compliance systems, financial credentials, professional certifications, or gaming achievements, SAS gives you the tools to issue and verify claims in a decentralized, transparent way.
+The Solana Attestation Service (SAS) provides a powerful foundation for building trust and identity systems on Solana. Whether you're creating compliance systems, financial credentials, professional certifications, or gaming achievements, SAS gives you the tools to issue and verify claims in a decentralized, transparent way.
 
 **Want to learn more?** Check out our [Guide: Encrypted Tokenized Attestations with Lit Protocol](/guides/ts/lit-encrypted-attestations/tokenized-attestation-flow).
 

--- a/docs/pages/guides/ts/lit-encrypted-attestations/basic-attestation-flow.mdx
+++ b/docs/pages/guides/ts/lit-encrypted-attestations/basic-attestation-flow.mdx
@@ -1,349 +1,70 @@
 ---
-title: Encrypted Attestation Data with Lit Protocol
+title: Encrypted Basic Attestation Flow
 description: Learn how to encrypt and control access to attestation data using Lit Protocol's decentralized key management network
 date: 2025-08-12
 ---
 
-# Encrypted Attestation Data with Lit Protocol
+# Encrypted Basic Attestation Flow
 
-## Introduction
+This guide will walk you through integrating Lit encryption into the [Basic Attestation Flow](/guides/ts/how-to-create-digital-credentials) example.
 
-When creating attestations on Solana, you may need to handle sensitive data that shouldn't be publicly visible on-chain. While blockchain provides transparency and immutability, certain attestation use cases require privacy controls - such as medical records, academic transcripts, or confidential business certifications.
-
-This guide demonstrates how to create **encrypted attestations** by combining Solana's attestation capabilities with [Lit Protocol](https://litprotocol.com), a decentralized key management network that enables secure encryption and programmable access control.
-
-### Why Lit Protocol?
-
-Lit Protocol provides a decentralized key management network that solves Web3's security dilemma: how to manage secrets without trusting centralized servers or burdening users with complex key management.
-
-#### Identity-Based Encryption Architecture
-
-Each Lit node runs in a Trusted Execution Environment (TEE) powered by sealed AMD SEV-SNP hardware that isolates key material from node operators.
-
-Lit's encryption uses Identity-Based Encryption with BLS signatures:
-
-1. **Network BLS key generation**: Participating Lit nodes collectively generate a network wide BLS public/private key pair using Distributed Key Generation (DKG)
-2. **Encryption process**: Data is encrypted using the network's BLS public key, with your access control conditions serving as the "identity"
-3. **Decryption policy**: The access control conditions (like wallet ownership, token holdings, or custom logic) become the identity that must be proven for decryption
-
-#### Threshold Decryption Process
-
-To decrypt data, a threshold of more than two-thirds of Lit nodes must collaborate, each providing a BLS signature share:
-
-1. **Policy verification**: Each node independently verifies that your access control conditions are met (checking on-chain state, signatures, etc.)
-2. **Signature share creation**: If conditions are satisfied, each node uses their BLS private key share to sign the identity (your access control policy)
-3. **Threshold reconstruction**: Once enough signature shares are collected, they're combined to create the complete BLS signature
-4. **Data decryption**: The reconstructed BLS signature serves as the decryption key to decrypt your ciphertext
-
-This Identity-Based Encryption approach ensures that decryption keys are generated on-demand only when authorization conditions are met, with no pre-shared secrets or centralized key storage.
-
-## Getting Started
-
-This guide will walk you through creating a complete encrypted attestation script that:
-
-- Creates credential and schema accounts on Solana
-- Encrypts sensitive attestation data using Lit Protocol's decentralized network
-- Stores the encrypted metadata on-chain, keeping the attestation data private
-- Implements SIWS (Sign In With Solana) authentication for decryption using Lit's Identity-Based Encryption, ensuring that only authorized signers can decrypt attestation data
-- Verifies attestations for both attested and non-attested users
-- Verifies that only authorized signers can decrypt attestation data
-- Closes an attestation (effectively revoking a user's credential)
-
-The end goal will be to see a working attestation system in action:
-
-```shell
-================================================================================
-SOLANA ATTESTATION SERVICE WITH LIT PROTOCOL ENCRYPTED ATTESTATION DEMO
-================================================================================
-
-📋 DEMO CONFIGURATION:
-   Network: localnet
-   Organization: LIT-ENCRYPTED-ATTESTATIONS
-   Schema: LIT-ENCRYPTED-METADATA (v1)
-
-🔑 CREATED ACCOUNTS:
-   Credential PDA:    HhU8FzCALX7XThBoPUQnJWAZMJdDeXctdxbedbT4kshV
-   Schema PDA:        HvLgB2BjQN3BzjQszYw6xuCCMpWPEkfs4b1YMrRBEp7H
-   Attestation PDA:   41Tx4apNq6tocjY4FK4QXpZoTeybaPo1hK328SwvpLRf
-   Test User:         JCRGgpTgaun9581uounx61RSmiMxN8KazEjdCnJbBdwB
-
-🧪 VERIFICATION TEST RESULTS:
-   Test User Verification:     ✅ PASSED
-   Encrypted Metadata:
-     - Ciphertext: plYShVUjPEdl69jWh54tjutxcBEjx7GiCYH1KKfnowhqUWOPkH...
-     - Data Hash: 4efa888818ad5ba81b0e459037eb8c62a3f0bdf401de5372e21d8aa132a0a808
-   Decrypted Attestation Data: {"name":"test-user","age":100,"country":"usa"}
-   Random User Verification:   ✅ PASSED (correctly rejected)
-   Unauthorized Signer Test:   ✅ PASSED (correctly rejected)
-   ✅ ALL TESTS PASSED! Demo completed successfully.
-
-================================================================================
-```
-
-### Prerequisites
+## Prerequisites
 
 Before starting this guide, you should have:
 
 - [**Node.js**](https://nodejs.org/en/download) (v22 or later)
 - [**Solana CLI**](https://solana.com/docs/intro/installation) v2.2.x or greater
 - [TypeScript](http://typescriptlang.org/) Experience
+- A working implementation of the [Basic Attestation Flow](/guides/ts/how-to-create-digital-credentials) guide
+- All of the prerequisite Lit helpers functions from the [Getting Started](/guides/ts/lit-encrypted-attestations/getting-started) guide
 
-Additionally, this guide builds on top of the [Basic Solana Attestation Flow](/guides/ts/how-to-create-digital-credentials) guide, so you should have a working implementation of that guide before starting this one.
+## Updating the Existing Implementation
 
-## Understanding Lit Encryption
-
-To effectively use Lit Protocol for encrypted attestations, it's important to understand the key components and how they work together to provide secure, programmable access control.
-
-### Lit Actions
-
-Lit Actions are JavaScript programs that run inside the secure hardware (TEEs) of Lit nodes across the decentralized Lit Protocol network.
-
-They are similar to smart contracts, but can interact with both on-chain and off-chain data to perform complex authorization logic.
-
-Each Lit node independently executes the same Lit Action in isolation, and more than two-thirds of nodes must agree on the result for consensus. This allows Lit Actions to securely:
-
-- Fetch data from external APIs (like Solana RPC endpoints).
-- Perform complex authorization logic.
-- Only authorize decryption when specific conditions are met.
-
-The Lit Action for this attestation demo acts as an authorization gatekeeper for decryption. It performs four key checks:
-
-1. **SIWS Authentication**: Validates the SIWS message, ensuring correct format, unexpired timestamp, and a valid signature from the claimed wallet.
-2. **Credential Verification**: Fetches the credential account from Solana, confirming its existence, correct program ownership, and data integrity.
-3. **Authorization**: Checks if the SIWS wallet address is listed as an authorized signer in the credential.
-4. **Conditional Decryption**: Only if all checks pass, the Lit Action decrypts and returns the attestation data; otherwise, access is denied.
-
-This ensures only explicitly authorized wallets can decrypt attestation data.
-
-### Access Control Conditions
-
-Access Control Conditions (ACCs) are the rules that determine who can decrypt your data, and under what circumstances. The Lit network will only allow decryption if these specific conditions are met.
-
-For this attestation demo, the ACCs are structured as:
-
-```typescript
-import ipfsOnlyHash from 'typestub-ipfs-only-hash'
-
-// This is the custom Lit Action created for this demo,
-// we'll be diving into it's implementation later in this guide
-import { litActionCode as litActionCodeDecrypt } from '../litActionDecrypt'
-
-const accessControlConditions = [
-    {
-        method: '',
-        params: [':currentActionIpfsId'],
-        pdaParams: [],
-        pdaInterface: { offset: 0, fields: {} },
-        pdaKey: '',
-        chain: 'solana',
-        returnValueTest: {
-            key: '',
-            comparator: '=',
-            value: await ipfsOnlyHash.of(litActionCodeDecrypt),
-        },
-    },
-]
-```
-
-Let's break down what each field means:
-
-- `params: [':currentActionIpfsId']`: A special parameter that gets the [IPFS CID](https://docs.ipfs.tech/concepts/content-addressing/) of the currently executing Lit Action
-- `chain: 'solana'`: Tells Lit Protocol this condition involves the Solana blockchain
-- `returnValueTest`: The authorization logic that must be satisfied for decryption to be permitted
-    - `comparator: '='`: The boolean operator used for comparison
-    - `value: await ipfsOnlyHash.of(litActionCodeDecrypt)`: The IPFS CID of our specific custom Lit Action for decryption
-
-This ACC is essentially saying:
-
-> "Only allow decryption if the request is coming from the Lit Action we specifically designed for authorizing attestation decryption."
-
-Since the Lit Action contains all the business logic for checking SIWS authentication and Solana credential authorization, this ACC ensures only authorized signers of the Solana credential can decrypt the attestation data.
-
-### Encryption Metadata
-
-When Lit encrypts your attestation data, it returns two crucial pieces of metadata that are required for decryption:
-
-- `ciphertext`: This is the actual encrypted version of your sensitive attestation data.
-- `dataToEncryptHash`: A cryptographic hash of the original data and the ACCs used to encrypted the data.
-
-## Project Setup
-
-_Prefer to jump straight to the code? Check out our [Examples Repo on GitHub](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript/attestation-flow-guides/src/lit/sas-standard-lit-demo.ts) for the complete code for this guide\!_
-
-As mentioned above, this guide builds on top of the [Basic Solana Attestation Flow](/guides/ts/how-to-create-digital-credentials) guide, so make sure you have a working implementation of that guide before continuing with this one.
-
-Let's start by adding the necessary dependencies to encrypt our attestation data with Lit:
-
-:::code-group
-
-```bash [npm]
-npm init -y
-npm i \
-    @lit-protocol/auth-helpers \
-    @lit-protocol/constants \
-    @lit-protocol/lit-node-client \
-npm i --save-dev @lit-protocol/types
-```
-
-```bash [pnpm]
-pnpm init
-pnpm i \
-    @lit-protocol/auth-helpers \
-    @lit-protocol/constants \
-    @lit-protocol/lit-node-client \
-pnpm i -D @lit-protocol/types
-```
-
-```bash [yarn]
-yarn init -y
-yarn add \
-    @lit-protocol/auth-helpers \
-    @lit-protocol/constants \
-    @lit-protocol/lit-node-client \
-yarn add -D @lit-protocol/types
-```
-
-:::
-
-Within your existing `solana-attestation-demo` directory, create a `lit` directory we can use to store our Lit related files:
-
-```bash
-mkdir lit
-```
-
-### Creating a Types file
-
-We'll cover each of the following types as we use them in this guide, but for now, let's create a `types.ts` file that will contain the types we'll be using:
-
-```ts
-/**
- * Sign-in With Solana (SIWS) messages (following Phantom's specification)
- * https://github.com/phantom/sign-in-with-solana/tree/main
- */
-export interface SiwsMessage {
-    /**
-     * Optional EIP-4361 domain requesting the sign-in.
-     * If not provided, the wallet must determine the domain to include in the message.
-     */
-    domain?: string
-    /**
-     * Optional Solana address performing the sign-in. The address is case-sensitive.
-     * If not provided, the wallet must determine the Address to include in the message.
-     */
-    address?: string
-    /**
-     * Optional EIP-4361 Statement. The statement is a human readable string and should not have new-line characters (\n).
-     * If not provided, the wallet must not include Statement in the message.
-     */
-    statement?: string
-    /**
-     * Optional EIP-4361 URI. The URL that is requesting the sign-in.
-     * If not provided, the wallet must not include URI in the message.
-     */
-    uri?: string
-    /**
-     * Optional EIP-4361 version.
-     * If not provided, the wallet must not include Version in the message.
-     */
-    version?: string
-    /**
-     * Optional EIP-4361 Chain ID.
-     * The chainId can be one of the following: mainnet, testnet, devnet, localnet, solana:mainnet, solana:testnet, solana:devnet.
-     * If not provided, the wallet must not include Chain ID in the message.
-     */
-    chainId?: string
-    /**
-     * Optional EIP-4361 Nonce.
-     * It should be an alphanumeric string containing a minimum of 8 characters.
-     * If not provided, the wallet must not include Nonce in the message.
-     */
-    nonce?: string
-    /**
-     * Optional ISO 8601 datetime string.
-     * This represents the time at which the sign-in request was issued to the wallet.
-     * Note: For Phantom, issuedAt has a threshold and it should be within +/- 10 minutes from the timestamp at which verification is taking place.
-     * If not provided, the wallet must not include Issued At in the message.
-     */
-    issuedAt?: string
-    /**
-     * Optional ISO 8601 datetime string.
-     * This represents the time at which the sign-in request should expire.
-     * If not provided, the wallet must not include Expiration Time in the message.
-     */
-    expirationTime?: string
-    /**
-     * Optional ISO 8601 datetime string.
-     * This represents the time at which the sign-in request becomes valid.
-     * If not provided, the wallet must not include Not Before in the message.
-     */
-    notBefore?: string
-    /**
-     * Optional EIP-4361 Request ID.
-     * In addition to using nonce to avoid replay attacks, dapps can also choose to include a unique signature in the requestId.
-     * Once the wallet returns the signed message, dapps can then verify this signature against the state to add an additional, strong layer of security.
-     * If not provided, the wallet must not include Request ID in the message.
-     */
-    requestId?: string
-    /**
-     * Optional EIP-4361 Resources.
-     * Usually a list of references in the form of URIs that the dapp wants the user to be aware of.
-     * These URIs should be separated by \n-, i.e., URIs in new lines starting with the character '-'.
-     * If not provided, the wallet must not include Resources in the message.
-     */
-    resources?: string[]
-}
-
-/**
- * Type-safe SIWS message for formatting - requires mandatory fields domain and address
- */
-export interface SiwsMessageForFormatting extends SiwsMessage {
-    domain: string // Required for message construction
-    address: string // Required for message construction
-}
-
-/**
- * Input for createSiwsMessage - requires address, all other fields optional
- */
-export interface SiwsMessageInput extends Partial<SiwsMessage> {
-    address: string // Address is mandatory for creation
-}
-
-export interface AttestationEncryptionMetadata {
-    ciphertext: string
-    dataToEncryptHash: string
-}
-
-export interface PkpInfo {
-    ethAddress: string
-    publicKey: string
-    tokenId: string
-}
-
-export interface LitDecryptionResponse {
-    success: boolean
-    message: string
-    error?: string
-    authorizedSigners?: string[]
-    requestingSigner?: string
-    decryptedData?: string
-}
-```
-
-## Updating the Existing Attestation Implementation
-
-Let's update the existing file, `attestation-demo.ts`, as well as create our Lit related files that allow us to encrypted our attestation data:
+Let's update the existing file, `attestation-demo.ts`, to utilize our Lit helpers functions to encrypt the attestation data:
 
 ### Imports and Configuration
 
-Start with the adding necessary imports:
-
-_Add these dependencies to the existing ones from the Basic Solana Attestation Flow guide._
+Start with the adding necessary imports, the following are all the imports required for this code example:
 
 ```ts
 import type { LitNodeClient } from '@lit-protocol/lit-node-client'
-import { fetchCredential } from 'sas-lib'
-import { KeyPairSigner } from 'gill'
+import {
+    getCreateCredentialInstruction,
+    getCreateSchemaInstruction,
+    serializeAttestationData,
+    getCreateAttestationInstruction,
+    fetchSchema,
+    getChangeAuthorizedSignersInstruction,
+    fetchAttestation,
+    deserializeAttestationData,
+    deriveAttestationPda,
+    deriveCredentialPda,
+    deriveSchemaPda,
+    deriveEventAuthorityAddress,
+    getCloseAttestationInstruction,
+    SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS,
+    fetchCredential,
+} from 'sas-lib'
+import {
+    airdropFactory,
+    generateKeyPairSigner,
+    lamports,
+    Signature,
+    TransactionSigner,
+    KeyPairSigner,
+    Instruction,
+    Address,
+    Blockhash,
+    createSolanaClient,
+    createTransaction,
+    SolanaClient,
+} from 'gill'
+import { estimateComputeUnitLimitFactory } from 'gill/programs'
 import { ethers } from 'ethers'
+
+import { createSiwsMessage, decryptAttestationData, encryptAttestationData, setupLit, signSiwsMessage } from './lit-helpers'
+import { AttestationEncryptionMetadata } from './types'
+import { getAuthorizedSigner1Keypair, getAuthorizedSigner2Keypair, getIssuerKeypair } from './get-keypair'
 ```
 
 Next, update the existing configuration:
@@ -373,138 +94,13 @@ For this example, the `SCHEMA_LAYOUT` is set to `Buffer.from([12, 12])` which co
 - the first `12` represents a String type for the `ciphertext` field,
 - the second `12` represents a String type for the `dataToEncryptHash` field.
 
-### Utility Functions
+### Updating `setupWallets`
 
-Next, we're going to make some modifications to the existing `setupWallets` helper function. Instead of generating new keypairs for `authorizedSigner1`, `authorizedSigner2`, and `issuer` every time we run the script, we're going to generate them once and same them to a keyfile.
+Next, we're going to make some modifications to the existing `setupWallets` helper function. Instead of generating new keypairs for `authorizedSigner1`, `authorizedSigner2`, and `issuer` every time we run the script, we're going to generate them once and save them as keyfiles in the directory: `key-pairs`.
 
-This is because we need to have a static and predetermined Credential PDA address that will be hardcoded within our Lit Action that handles the authorization checks and decryption. Hardcoding the Credential PDA allows the Lit Action to enforce that only authorized signers for the specific Credential are authorized to decrypt the attestation data.
+This is because we need to have a static and predetermined credential PDA that will be hardcoded within our Lit Action that handles the authorization checks and decryption. Hardcoding the credential PDA allows the Lit Action to enforce that only authorized signers for the specific credential are authorized to decrypt the attestation data.
 
-#### Creating the Authorized Signer and Issuer Keypairs
-
-Let's start by creating a new `get-keypair.ts` file that will handle generating new keypairs, saving them to a keyfile, and loading them from the keyfile:
-
-```ts
-import { existsSync, mkdirSync } from 'fs'
-import { generateExtractableKeyPairSigner } from 'gill'
-import { loadKeypairSignerFromFile, saveKeypairSignerToFile } from 'gill/node'
-import path from 'path'
-
-async function generateKeypair(outputPath: string) {
-    const extractableSigner = await generateExtractableKeyPairSigner()
-    await saveKeypairSignerToFile(extractableSigner, outputPath)
-}
-
-async function getKeyPair(keyPairName: string) {
-    const keyPairDir = 'key-pairs'
-    const keyPairPath = path.join(keyPairDir, `${keyPairName}.keypair.json`)
-    if (!existsSync(keyPairPath)) {
-        // Ensure the directory exists before creating the file
-        if (!existsSync(keyPairDir)) {
-            mkdirSync(keyPairDir, { recursive: true })
-        }
-        console.log(`${keyPairName} keypair does not exist at path: ${keyPairPath}. Generating it...`)
-        await generateKeypair(keyPairPath)
-    }
-
-    return loadKeypairSignerFromFile(keyPairPath)
-}
-
-export async function getIssuerKeypair() {
-    const keypair = await getKeyPair('issuer')
-    console.log(`Got Issuer keypair with address: ${keypair.address}`)
-    return keypair
-}
-
-export async function getAuthorizedSigner1Keypair() {
-    const keypair = await getKeyPair('authorized-signer-1')
-    console.log(`Got Authorized Signer 1 keypair with address: ${keypair.address}`)
-    return keypair
-}
-
-export async function getAuthorizedSigner2Keypair() {
-    const keypair = await getKeyPair('authorized-signer-2')
-    console.log(`Got Authorized Signer 2 keypair with address: ${keypair.address}`)
-    return keypair
-}
-```
-
-#### Deriving the Credential PDA from the Issuer Keypair
-
-Next we'll create a new helper script called `generate-credential-pda.ts` that will generate a new or load an existing Issuer keypair, and use it to derive the Credential PDA address:
-
-```ts
-import { deriveCredentialPda } from 'sas-lib'
-
-import { getIssuerKeypair } from './get-keypair'
-
-async function main() {
-    console.log('Starting credential PDA generator\n')
-
-    // Step 1: Get issuer keypair
-    console.log('1. Getting Issuer keypair...')
-    const issuer = await getIssuerKeypair()
-
-    // Step 2: Create Credential
-    console.log('\n2. Creating Credential...')
-    const [credentialPda] = await deriveCredentialPda({
-        authority: issuer.address,
-        name: 'LIT-ENCRYPTED-METADATA',
-    })
-
-    console.log(`Credential PDA: ${credentialPda}`)
-}
-
-main()
-    .then(() => console.log('\nCredential PDA generated successfully!'))
-    .catch(error => {
-        console.error('❌ Failed to generate credential PDA:', error)
-        process.exit(1)
-    })
-```
-
-To run this helper script, we'll add a new script to our `package.json` file:
-
-```json
-"scripts": {
-  "generate-credential-pda": "ts-node generate-credential-pda.ts",
-}
-```
-
-##### Running the Generate Credential PDA Script
-
-Before continuing with this guide, you'll need to run this script which will generate the Issuer keypair and Credential PDA, and save their keyfiles to a directory called `key-pairs`. After running the script, you should see output similar to:
-
-```bash
-pnpm generate-credential-pda
-
-> solana-attestation-demo-ts@1.0.0 generate-credential-pda attestation-flow-guides
-> ts-node src/lit/generate-credential-pda.ts
-
-Starting credential PDA generator
-
-1. Getting Issuer keypair...
-issuer keypair does not exist at path: key-pairs/issuer.keypair.json. Generating it...
-Got Issuer keypair with address: EFjEXBpSHL7xXUNZEQf5CKWD7dZHkLfqc1i9tceoqms2
-
-2. Creating Credential...
-Credential PDA: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
-
-Credential PDA generated successfully!
-```
-
-The line: `Credential PDA: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk` is important and what we'll need to hardcode into our Lit Action later in this guide.
-
-#### Updating the Setup Wallets Function
-
-Now that we have our keyfiles generated, and some helper functions to load them, we can update the `setupWallets` function to load the keypairs from the keyfiles instead of generating new ones every time.
-
-First add the import in the `attestation-demo.ts` file:
-
-```ts
-import { getAuthorizedSigner1Keypair, getAuthorizedSigner2Keypair, getIssuerKeypair } from './get-keypair'
-```
-
-Then update the `setupWallets` function to load the keypairs from the keyfiles:
+Update the `setupWallets` function to load the keypairs from the keyfiles if they exist, otherwise generate new ones:
 
 ```ts
 async function setupWallets(client: SolanaClient) {
@@ -534,14 +130,7 @@ This is a key change to the existing Basic Solana Attestation Flow, and without 
 
 ### Updating the Attestation Verification Function
 
-We'll be modifying the existing `verifyAttestation` function to handle retrieving the Lit encryption metadata from the on-chain attestation data, and decrypting by submitting a signed Sign-in-with-Solana (SIWS) message to our custom decryption Lit Action.
-
-_Make sure to add the following imports to the top of the file:_
-
-```ts
-import { createSiwsMessage, decryptAttestationData, signSiwsMessage } from './lit-helpers'
-import { AttestationEncryptionMetadata } from './types'
-```
+Next we'll be modifying the existing `verifyAttestation` function to handle retrieving the Lit encryption metadata from the on-chain attestation data, and decrypting it by submitting a signed SIWS message to our custom decryption Lit Action.
 
 ```ts
 async function verifyAttestation({
@@ -614,1132 +203,61 @@ Let's cover the differences between the existing `verifyAttestation` function an
 - New return value type for `deserializeAttestationData`:
     - Previously, this function call returned the raw attestation data that was stored on-chain, but now it's returning `AttestationEncryptionMetadata` (as defined in our [`types.ts` file](#creating-a-types-file)) which is our Lit encryption metadata: `ciphertext` and `dataToEncryptHash`.
 
-#### Diving into the Decryption Process
+## Setting Up the `main` Function
 
-As a prerequisite to making the decryption request to the Lit network, we need to create and sign a SIWS message with one of the Credential's Authorized Signer keypairs.
+Now that we've setup and covered all the parts of this demo, let's run it!
 
-##### Creating the SIWS Message
+The following demonstration script follows the same pattern as the Basic Attestation Flow guide, but with some changes that demonstrate how to use the helper functions we created above to encrypt the attestation data.
 
-Let's create the file `create-siws-message.ts` in our `lit` helpers directory, and export the function `createSiwsMessage`:
+### Prerequisites
 
-```ts
-import { SiwsMessageForFormatting, SiwsMessageInput } from '../types'
+As mentioned previously, before we can run the code example script, we need to generate the Issuer and Authorized Signers keypairs, derive the Credential PDA, and paste the address into our decryption Lit Action.
 
-/**
- * Creates a complete Siws message by filling in missing properties with sensible defaults
- * @param siws - Siws message object with required address field
- * @returns Complete Siws message with all fields populated
- */
-export function createSiwsMessage(siws: SiwsMessageInput): SiwsMessageForFormatting {
-    const now = new Date()
-    const expirationTime = new Date(now.getTime() + 10 * 60 * 1000) // 10 minutes
+To do this, we'll add a new script to our `package.json` file:
 
-    // Generate a proper nonce if not provided (minimum 8 characters, alphanumeric)
-    const generatedNonce = siws.nonce || Math.random().toString(36).substring(2, 12) // 10 character alphanumeric
-
-    // Merge siws with defaults, siws values take precedence
-    return {
-        domain: siws.domain || 'localhost',
-        address: siws.address,
-        statement: siws.statement || 'Sign this message to authenticate with Lit Protocol',
-        uri: siws.uri || 'http://localhost',
-        version: siws.version || '1',
-        chainId: siws.chainId || 'devnet', // Must be string as per Siws spec: mainnet, testnet, devnet, localnet, etc.
-        nonce: generatedNonce,
-        issuedAt: siws.issuedAt || now.toISOString(),
-        expirationTime: siws.expirationTime || expirationTime.toISOString(),
-        notBefore: siws.notBefore,
-        requestId: siws.requestId,
-        resources: siws.resources || [],
-    }
+```json
+"scripts": {
+  "generate-credential-pda": "ts-node generate-credential-pda.ts",
 }
 ```
 
-_As with the rest of this guide, any imported custom types are defined in the [`types.ts` file](#creating-a-types-file) we created previously._
+And run it:
 
-This helper function utilizes [Phantom's SIWS message specification](https://github.com/phantom/sign-in-with-solana/tree/main), and is used to prove the identity of a Credential signer to the Lit network. This SIWS message is part of the authorization process in our custom Lit Action that will gatekeep who is permitted to decrypt the attestation data.
+:::code-group
 
-##### Signing the SIWS Message
-
-Going back to the `verifyAttestation` function, the next step after creating the SIWS message is to sign it with a Credential's Authorized Signer keypair. To do this we'll create the file `sign-siws-message.ts` in our `lit` helpers directory, and export the function `signSiwsMessage`:
-
-```ts
-import { ethers } from 'ethers'
-import { createSignableMessage, KeyPairSigner } from 'gill'
-
-import { SiwsMessageForFormatting } from '../types'
-import { formatSiwsMessage } from './format-siws-message'
-
-/**
- * Signs a SIWS message using a Solana keypair signer
- * @param siwsMessage - The formatted SIWS message to sign
- * @param signer - The Solana KeyPairSigner from setupWallets
- * @returns Base58-encoded signature
- */
-export async function signSiwsMessage(siwsMessage: SiwsMessageForFormatting, signer: KeyPairSigner): Promise<string> {
-    try {
-        const message = createSignableMessage(new TextEncoder().encode(formatSiwsMessage(siwsMessage)))
-        const signedMessage = await signer.signMessages([message])
-        return ethers.utils.base58.encode(signedMessage[0][signer.address])
-    } catch (error) {
-        throw new Error(`Failed to sign SIWS message: ${error instanceof Error ? error.message : 'Unknown error'}`)
-    }
-}
+```bash [npm]
+npm run generate-credential-pda
 ```
 
-This utilizes a helper function, `formatSiwsMessage`, that makes sure our SIWS message object is properly formatted as defined in Phantom's SIWS message specification.
-
-##### Formatting the SIWS Message
-
-Create the file `format-siws-message.ts` in our `lit` helpers directory, and export the function `formatSiwsMessage`:
-
-```ts
-import { SiwsMessageForFormatting } from '../types'
-
-/**
- * Formats SIWS message according to the ABNF specification:
- * https://github.com/phantom/sign-in-with-solana/blob/main/siws.md#abnf-message-format
- *
- * @param siws - SIWS message with required domain and address fields
- * @returns Formatted message string according to Siws ABNF specification
- */
-export function formatSiwsMessage(siws: SiwsMessageForFormatting): string {
-    if (!siws.domain || !siws.address) {
-        throw new Error('Domain and address are required for Siws message construction')
-    }
-
-    // Start with the mandatory domain and address line
-    let message = `${siws.domain} wants you to sign in with your Solana account:\n${siws.address}`
-
-    // Add statement if provided (with double newline separator)
-    if (siws.statement) {
-        message += `\n\n${siws.statement}`
-    }
-
-    // Collect advanced fields in the correct order as per ABNF spec
-    const fields: string[] = []
-
-    if (siws.uri) {
-        fields.push(`URI: ${siws.uri}`)
-    }
-    if (siws.version) {
-        fields.push(`Version: ${siws.version}`)
-    }
-    if (siws.chainId) {
-        fields.push(`Chain ID: ${siws.chainId}`)
-    }
-    if (siws.nonce) {
-        fields.push(`Nonce: ${siws.nonce}`)
-    }
-    if (siws.issuedAt) {
-        fields.push(`Issued At: ${siws.issuedAt}`)
-    }
-    if (siws.expirationTime) {
-        fields.push(`Expiration Time: ${siws.expirationTime}`)
-    }
-    if (siws.notBefore) {
-        fields.push(`Not Before: ${siws.notBefore}`)
-    }
-    if (siws.requestId) {
-        fields.push(`Request ID: ${siws.requestId}`)
-    }
-    if (siws.resources && siws.resources.length > 0) {
-        fields.push(`Resources:`)
-        for (const resource of siws.resources) {
-            fields.push(`- ${resource}`)
-        }
-    }
-
-    // Add advanced fields if any exist (with double newline separator)
-    if (fields.length > 0) {
-        message += `\n\n${fields.join('\n')}`
-    }
-
-    return message
-}
+```bash [pnpm]
+pnpm generate-credential-pda
 ```
 
-##### Making the Decryption Request
-
-Lastly, back in the `verifyAttestation` function, we'll use the `decryptAttestationData` helper function to make the decryption request to the Lit network.
-
-Create the file `decrypt-attestation-data.ts` in our `lit` helpers directory, and export the function `decryptAttestationData`:
-
-```ts
-import { LitNodeClient } from '@lit-protocol/lit-node-client'
-import { generateAuthSig, createSiweMessage, LitAccessControlConditionResource, LitActionResource } from '@lit-protocol/auth-helpers'
-import { LIT_ABILITY } from '@lit-protocol/constants'
-import { ethers } from 'ethers'
-
-import { LitDecryptionResponse, SiwsMessageForFormatting } from '../types'
-import { litActionCode as litActionCodeDecrypt } from '../litActionDecrypt'
-
-export const decryptAttestationData = async ({
-    litNodeClient,
-    litPayerEthersWallet,
-    ciphertext,
-    dataToEncryptHash,
-    siwsMessage,
-    siwsMessageSignature,
-}: {
-    litNodeClient: LitNodeClient
-    litPayerEthersWallet: ethers.Wallet
-    ciphertext: string
-    dataToEncryptHash: string
-    siwsMessage: SiwsMessageForFormatting
-    siwsMessageSignature: string
-}) => {
-    try {
-        const response = await litNodeClient.executeJs({
-            code: litActionCodeDecrypt,
-            sessionSigs: await litNodeClient.getSessionSigs({
-                chain: 'ethereum',
-                expiration: new Date(Date.now() + 1000 * 60 * 10).toISOString(), // 10 minutes
-                resourceAbilityRequests: [
-                    {
-                        resource: new LitActionResource('*'),
-                        ability: LIT_ABILITY.LitActionExecution,
-                    },
-                    {
-                        resource: new LitAccessControlConditionResource('*'),
-                        ability: LIT_ABILITY.AccessControlConditionDecryption,
-                    },
-                ],
-                authNeededCallback: async ({ uri, expiration, resourceAbilityRequests }) => {
-                    const toSign = await createSiweMessage({
-                        uri,
-                        expiration,
-                        resources: resourceAbilityRequests,
-                        walletAddress: await litPayerEthersWallet.getAddress(),
-                        nonce: await litNodeClient.getLatestBlockhash(),
-                        litNodeClient,
-                    })
-
-                    return await generateAuthSig({
-                        signer: litPayerEthersWallet,
-                        toSign,
-                    })
-                },
-            }),
-            jsParams: {
-                siwsMessage: JSON.stringify(siwsMessage),
-                siwsMessageSignature,
-                ciphertext,
-                dataToEncryptHash,
-            },
-        })
-
-        const responseJSON = JSON.parse(response.response as string) as LitDecryptionResponse
-
-        if (!responseJSON.hasOwnProperty('success')) {
-            throw new Error(`Unexpected return value from Lit decryption request: ${response.response}`)
-        }
-
-        if (responseJSON.success === false) {
-            throw new Error(`Failed to decrypt attestation data: ${response.response}`)
-        }
-
-        return responseJSON.decryptedData
-    } catch (error) {
-        throw new Error(`An unexpected error occurred while decrypting the attestation data: ${error instanceof Error ? error.message : 'Unknown error'}`)
-    }
-}
-```
-
-This function is the main integration point for the Lit SDK, and it's responsible for setting up and executing the request to the Lit network to execute our custom Lit Action that authorizes decryption of the attestation data.
-
-For the input parameters for this function, we'll cover `litNodeClient` and `litPayerEthersWallet` in more detail later in this guide, and the remaining are as follows:
-
-- `ciphertext`: This is the encrypted attestation data that we'll be decrypting, and was obtained from the on-chain attestation data.
-- `dataToEncryptHash`: This is the hash of the data that was encrypted along with our Access Control Conditions, and was also obtained from the on-chain attestation data.
-- `siwsMessage`: This is the SIWS message that we [created previously](#creating-the-siws-message) and is used in the authorization process that validates the person making the decryption request is permitted to decrypt the attestation data.
-- `siwsMessageSignature`: This is the signature of the SIWS message that was [previously signed](#signing-the-siws-message) with one of the Credential's Authorized Signer keypairs.
-
-The `litNodeClient.executeJs` function is used to execute our custom Lit Action and takes several parameters:
-
-###### `code`
-
-```ts
-code: litActionCodeDecrypt,
-```
-
-This is the code for our custom Lit Action that will be executed on the Lit network. The code can be uploaded to IPFS and referenced here using it's IPFS CID, or the code can be provided as a string as we're doing in this guide.
-
-We setup and dive into the Lit Action code in the [Decryption Lit Action](#the-decryption-lit-action) section.
-
-###### `sessionSigs`
-
-```ts
-sessionSigs: await litNodeClient.getSessionSigs({
-    chain: "ethereum",
-    expiration: new Date(Date.now() + 1000 * 60 * 10).toISOString(), // 10 minutes
-    resourceAbilityRequests: [
-        {
-            resource: new LitActionResource("*"),
-            ability: LIT_ABILITY.LitActionExecution,
-        },
-        {
-            resource: new LitAccessControlConditionResource("*"),
-            ability: LIT_ABILITY.AccessControlConditionDecryption,
-        },
-    ],
-    authNeededCallback: async ({
-        uri,
-        expiration,
-        resourceAbilityRequests,
-    }) => {
-        const toSign = await createSiweMessage({
-            uri,
-            expiration,
-            resources: resourceAbilityRequests,
-            walletAddress: await litPayerEthersWallet.getAddress(),
-            nonce: await litNodeClient.getLatestBlockhash(),
-            litNodeClient,
-        });
-
-        return await generateAuthSig({
-            signer: litPayerEthersWallet,
-            toSign,
-        });
-    },
-}),
-```
-
-Similar to paying for gas when using a blockchain, payment is required when making requests to the Lit network that require execution by the Lit nodes e.g. decrypting data. Session Signatures are how your identity is proven to the Lit network so that payment for your request can be processed. Additionally, a Session can be restricited to only permit specific tasks such as executing Lit Actions and decrypting data, as done in this guide.
-
-Session Signatures are created by specifying what `resourceAbilityRequests` are permitted to be executed using the Session, and an authentication function given to `authNeededCallback` to prove your identity. In this guide we're signing a Sign-in-with-Ethereum message using an Ethereum wallet which we generate randomly everytime the script is run.
-
-For this guide, the identity of the person paying for the decryption request to the Lit network is irrelevant, as we're using the Lit Datil-dev network which doesn't actually charge for usage of the network, however we're still required to authenticate with the Lit network via a Session.
-
-If you'd like to transition this guide to use the Lit Datil-test or mainnet, you'll need to learn about [paying for usage of the Lit network](https://developer.litprotocol.com/paying-for-lit/overview). You can also learn more about how Session Signatures work, and how to customize them [here](https://developer.litprotocol.com/sdk/authentication/session-sigs/intro).
-
-###### `jsParams`
-
-```ts
-jsParams: {
-  siwsMessage: JSON.stringify(siwsMessage),
-  siwsMessageSignature,
-  ciphertext,
-  dataToEncryptHash,
-},
-```
-
-The `jsParams` is an object or parameters that will be injected into the Lit Action runtime as global variables. So the keys of this object will be the variable names, and the object values will be the values of the parameters as defined here.
-
-Our custom Lit Action requires the raw SIWS message, the signature of the SIWS message, and the Lit encryption metadata in order to perform the authorization checks and decrypt the attestation data.
-
-##### The Decryption Lit Action
-
-Create the file `litActionDecrypt.ts` outside of the `lit` helpers directory (put the file in the same directory as the `attestation-demo.ts` file), and copy and paste the following code:
-
-:::details[Below we'll be diving into the Lit Action code, piece by piece, but click here to view the complete Lit Action Code.]
-
-```ts
-// @ts-nocheck
-
-const _litActionCode = async () => {
-    // Hardcoded values for this specific attestation service instance
-    const AUTHORIZED_RPC_URL = 'https://api.devnet.solana.com'
-    const AUTHORIZED_PROGRAM_ID = '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG'
-    const AUTHORIZED_CREDENTIAL_PDA = 'Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk'
-
-    async function fetchAccountData(rpcUrl, address) {
-        try {
-            const response = await fetch(rpcUrl, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    jsonrpc: '2.0',
-                    id: 1,
-                    method: 'getAccountInfo',
-                    params: [address, { encoding: 'base64', commitment: 'confirmed' }],
-                }),
-            })
-
-            const data = await response.json()
-            if (data.error) {
-                throw new Error(`RPC error: ${data.error.message}`)
-            }
-
-            if (!data.result || !data.result.value) {
-                throw new Error('Account not found')
-            }
-
-            const accountInfo = data.result.value
-            return {
-                data: ethers.utils.base64.decode(accountInfo.data[0]),
-                owner: accountInfo.owner,
-            }
-        } catch (error) {
-            console.error('Error fetching account data:', error)
-            throw error
-        }
-    }
-
-    function parseCredentialAccount(data) {
-        let offset = 0
-
-        // Skip discriminator (1 byte)
-        offset += 1
-
-        // Read authority (32 bytes)
-        const authority = ethers.utils.base58.encode(data.slice(offset, offset + 32))
-        offset += 32
-
-        // Read name length (4 bytes, little-endian)
-        const nameLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
-        offset += 4
-
-        // Skip name bytes
-        offset += nameLength
-
-        // Read authorized signers length (4 bytes, little-endian)
-        const signersLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
-        offset += 4
-
-        // Read authorized signers
-        const authorizedSigners = []
-        for (let i = 0; i < signersLength; i++) {
-            const signer = ethers.utils.base58.encode(data.slice(offset, offset + 32))
-            authorizedSigners.push(signer)
-            offset += 32
-        }
-
-        return { authority, authorizedSigners }
-    }
-
-    function getSiwsMessage(siwsInput) {
-        console.log('Attempting to parse SIWS message: ', siwsInput)
-
-        if (!siwsInput.domain || !siwsInput.address) {
-            throw new Error('Domain and address are required for Siws message construction')
-        }
-
-        // Start with the mandatory domain and address line
-        let message = `${siwsInput.domain} wants you to sign in with your Solana account:\n${siwsInput.address}`
-
-        // Add statement if provided (with double newline separator)
-        if (siwsInput.statement) {
-            message += `\n\n${siwsInput.statement}`
-        }
-
-        // Collect advanced fields in the correct order as per ABNF spec
-        const fields = []
-
-        if (siwsInput.uri) {
-            fields.push(`URI: ${siwsInput.uri}`)
-        }
-        if (siwsInput.version) {
-            fields.push(`Version: ${siwsInput.version}`)
-        }
-        if (siwsInput.chainId) {
-            fields.push(`Chain ID: ${siwsInput.chainId}`)
-        }
-        if (siwsInput.nonce) {
-            fields.push(`Nonce: ${siwsInput.nonce}`)
-        }
-        if (siwsInput.issuedAt) {
-            fields.push(`Issued At: ${siwsInput.issuedAt}`)
-        }
-        if (siwsInput.expirationTime) {
-            fields.push(`Expiration Time: ${siwsInput.expirationTime}`)
-        }
-        if (siwsInput.notBefore) {
-            fields.push(`Not Before: ${siwsInput.notBefore}`)
-        }
-        if (siwsInput.requestId) {
-            fields.push(`Request ID: ${siwsInput.requestId}`)
-        }
-        if (siwsInput.resources && siwsInput.resources.length > 0) {
-            fields.push(`Resources:`)
-            for (const resource of siwsInput.resources) {
-                fields.push(`- ${resource}`)
-            }
-        }
-
-        // Add advanced fields if any exist (with double newline separator)
-        if (fields.length > 0) {
-            message += `\n\n${fields.join('\n')}`
-        }
-
-        return message
-    }
-
-    function validateSiwsMessage(siwsInput) {
-        const now = new Date()
-
-        // Check if message has expired (expirationTime is in the past)
-        if (siwsInput.expirationTime) {
-            const expirationTime = new Date(siwsInput.expirationTime)
-            if (now > expirationTime) {
-                return {
-                    valid: false,
-                    error: `SIWS message has expired. Current time: ${now.toISOString()}, Expiration: ${siwsInput.expirationTime}`,
-                }
-            }
-        }
-
-        // Check if message is not yet valid (notBefore is in the future)
-        if (siwsInput.notBefore) {
-            const notBefore = new Date(siwsInput.notBefore)
-            if (now < notBefore) {
-                return {
-                    valid: false,
-                    error: `SIWS message is not yet valid. Current time: ${now.toISOString()}, Not Before: ${siwsInput.notBefore}`,
-                }
-            }
-        }
-
-        return { valid: true }
-    }
-
-    async function verifySiwsSignature(siwsMessage, signerAddress, siwsMessageSignature) {
-        try {
-            const publicKey = await crypto.subtle.importKey(
-                'raw',
-                ethers.utils.base58.decode(signerAddress),
-                {
-                    name: 'Ed25519',
-                    namedCurve: 'Ed25519',
-                },
-                false,
-                ['verify']
-            )
-
-            const isValid = await crypto.subtle.verify(
-                'Ed25519',
-                publicKey,
-                ethers.utils.base58.decode(siwsMessageSignature),
-                new TextEncoder().encode(siwsMessage)
-            )
-
-            return isValid
-        } catch (error) {
-            console.error('Error in verifySiwsSignature:', error)
-            throw error
-        }
-    }
-
-    const siwsMessageJson = JSON.parse(siwsMessage)
-    const siwsMessageString = getSiwsMessage(siwsMessageJson)
-
-    try {
-        const siwsMessageValid = validateSiwsMessage(siwsMessageJson)
-        if (!siwsMessageValid.valid) {
-            console.log('SIWS message validation failed:', siwsMessageValid.error)
-            return LitActions.setResponse({
-                response: JSON.stringify({
-                    success: false,
-                    message: 'SIWS message validation failed.',
-                    error: siwsMessageValid.error,
-                }),
-            })
-        }
-    } catch (error) {
-        console.error('Error in validateSiwsMessage:', error)
-        return LitActions.setResponse({
-            response: JSON.stringify({
-                success: false,
-                message: 'Error in validateSiwsMessage.',
-                error: error.toString(),
-            }),
-        })
-    }
-
-    try {
-        const siwsSignatureValid = await verifySiwsSignature(siwsMessageString, siwsMessageJson.address, siwsMessageSignature)
-
-        if (!siwsSignatureValid) {
-            console.log('Signature is invalid.')
-            return LitActions.setResponse({
-                response: JSON.stringify({
-                    success: false,
-                    message: 'Signature is invalid.',
-                }),
-            })
-        }
-
-        console.log('Signature is valid.')
-    } catch (error) {
-        console.error('Error verifying signature:', error)
-        return LitActions.setResponse({
-            response: JSON.stringify({
-                success: false,
-                message: 'Error verifying signature.',
-                error: error.toString(),
-            }),
-        })
-    }
-
-    // Fetch and verify authorized signers from the hardcoded credential
-    try {
-        const accountInfo = await fetchAccountData(AUTHORIZED_RPC_URL, AUTHORIZED_CREDENTIAL_PDA)
-
-        // Verify the credential account is owned by the correct program
-        if (accountInfo.owner !== AUTHORIZED_PROGRAM_ID) {
-            console.log(`Credential PDA owner mismatch. Expected: ${AUTHORIZED_PROGRAM_ID}, Got: ${accountInfo.owner}`)
-            return LitActions.setResponse({
-                response: JSON.stringify({
-                    success: false,
-                    message: 'Credential PDA is not owned by the authorized program',
-                    expectedOwner: AUTHORIZED_PROGRAM_ID,
-                    actualOwner: accountInfo.owner,
-                }),
-            })
-        }
-
-        const credential = parseCredentialAccount(accountInfo.data)
-
-        // Check if the signer is authorized
-        const signerAddress = siwsMessageJson.address
-        if (!credential.authorizedSigners.includes(signerAddress)) {
-            console.log(`Signer ${signerAddress} is not in authorized signers list`)
-            return LitActions.setResponse({
-                response: JSON.stringify({
-                    success: false,
-                    message: 'Signer is not authorized to decrypt',
-                    authorizedSigners: credential.authorizedSigners,
-                    requestingSigner: signerAddress,
-                }),
-            })
-        }
-
-        console.log(`Signer ${signerAddress} is authorized to decrypt`)
-    } catch (error) {
-        console.error('Error checking authorized signers:', error)
-        return LitActions.setResponse({
-            response: JSON.stringify({
-                success: false,
-                message: 'Error checking authorized signers',
-                error: error.toString(),
-            }),
-        })
-    }
-
-    try {
-        const decryptedData = await Lit.Actions.decryptAndCombine({
-            accessControlConditions: [
-                {
-                    method: '',
-                    params: [':currentActionIpfsId'],
-                    pdaParams: [],
-                    pdaInterface: { offset: 0, fields: {} },
-                    pdaKey: '',
-                    chain: 'solana',
-                    returnValueTest: {
-                        key: '',
-                        comparator: '=',
-                        value: LitAuth.actionIpfsIds[0],
-                    },
-                },
-            ],
-            ciphertext,
-            dataToEncryptHash,
-            authSig: {
-                sig: ethers.utils.hexlify(ethers.utils.base58.decode(siwsMessageSignature)).slice(2),
-                derivedVia: 'solana.signMessage',
-                signedMessage: siwsMessageString,
-                address: siwsMessageJson.address,
-            },
-            chain: 'solana',
-        })
-        return LitActions.setResponse({ response: JSON.stringify({ success: true, decryptedData }) })
-    } catch (error) {
-        console.error('Error decrypting data:', error)
-        return LitActions.setResponse({
-            response: JSON.stringify({
-                success: false,
-                message: 'Error decrypting data.',
-                error: error.toString(),
-            }),
-        })
-    }
-}
-
-export const litActionCode = `(${_litActionCode.toString()})()`
+```bash [yarn]
+yarn generate-credential-pda
 ```
 
 :::
 
-##### The Structure of the Lit Action Code
+You should see output similar to the following:
 
-When providing the Lit Action code to the Lit SDK, you'll need to provide it as a stringified self executing function which looks like this:
+```bash
+> solana-attestation-demo-ts@1.0.0 generate-credential-pda attestation-flow-guides
+> ts-node src/lit/generate-credential-pda.ts
 
-```ts
-const _litActionCode = async () => {
-    // Lit Action code...
-}
+Starting credential PDA generator
 
-export const litActionCode = `(${_litActionCode.toString()})()`
+1. Getting Issuer keypair...
+issuer keypair does not exist at path: key-pairs/issuer.keypair.json. Generating it...
+Got Issuer keypair with address: EFjEXBpSHL7xXUNZEQf5CKWD7dZHkLfqc1i9tceoqms2
+
+2. Creating Credential...
+Credential PDA: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
+
+Credential PDA generated successfully!
 ```
 
-The `litActionCode` is the stringified self executing function, and what we imported and provide to the Lit SDK as the [code](#code) parameter to the `litNodeClient.executeJs` call.
-
-##### Hardcoded Solana Constants
-
-```ts
-const _litActionCode = async () => {
-    // Hardcoded values for this specific attestation service instance
-    const AUTHORIZED_RPC_URL = 'https://api.devnet.solana.com'
-    const AUTHORIZED_PROGRAM_ID = '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG'
-    const AUTHORIZED_CREDENTIAL_PDA = 'Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk'
-
-    // The rest of the Lit Action code...
-}
-```
-
-- The `AUTHORIZED_RPC_URL` is the RPC URL of the Solana cluster that the attestation service is running on.
-- The `AUTHORIZED_PROGRAM_ID` is the program ID of the attestation service.
-- The `AUTHORIZED_CREDENTIAL_PDA` is the Credential PDA that was derived from the Issuer keypair.
-    - This PDA is unique to your Issuer keypair and is used to identify whether the requestor of the decryption request is authorized to decrypt the attestation data.
-    - We generated this PDA earlier in the [Running the Generate Credential PDA Script](#running-the-generate-credential-pda-script) section:
-        ```bash
-        2. Creating Credential...
-        Credential PDA: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
-        ```
-
-##### Fetching Account Data
-
-```ts
-const _litActionCode = async () => {
-    // Previous Lit Action code...
-
-    async function fetchAccountData(rpcUrl, address) {
-        try {
-            const response = await fetch(rpcUrl, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    jsonrpc: '2.0',
-                    id: 1,
-                    method: 'getAccountInfo',
-                    params: [address, { encoding: 'base64', commitment: 'confirmed' }],
-                }),
-            })
-
-            const data = await response.json()
-            if (data.error) {
-                throw new Error(`RPC error: ${data.error.message}`)
-            }
-
-            if (!data.result || !data.result.value) {
-                throw new Error('Account not found')
-            }
-
-            const accountInfo = data.result.value
-            return {
-                data: ethers.utils.base64.decode(accountInfo.data[0]),
-                owner: accountInfo.owner,
-            }
-        } catch (error) {
-            console.error('Error fetching account data:', error)
-            throw error
-        }
-    }
-
-    // The rest of the Lit Action code...
-}
-```
-
-The `fetchAccountData` function is a utility method that allows the Lit Action to query Solana's blockchain state directly from within the secure execution environment. It fetches and decodes account data from Solana using the `getAccountInfo` RPC call, handling errors, and returning both the account's data and owner. This will enable the Lit Action to check which signers are authorized to decrypt the attestation later in the code.
-
-##### Parsing the Credential Account Data
-
-```ts
-const _litActionCode = async () => {
-    // Previous Lit Action code...
-
-    function parseCredentialAccount(data) {
-        let offset = 0
-
-        // Skip discriminator (1 byte)
-        offset += 1
-
-        // Read authority (32 bytes)
-        const authority = ethers.utils.base58.encode(data.slice(offset, offset + 32))
-        offset += 32
-
-        // Read name length (4 bytes, little-endian)
-        const nameLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
-        offset += 4
-
-        // Skip name bytes
-        offset += nameLength
-
-        // Read authorized signers length (4 bytes, little-endian)
-        const signersLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
-        offset += 4
-
-        // Read authorized signers
-        const authorizedSigners = []
-        for (let i = 0; i < signersLength; i++) {
-            const signer = ethers.utils.base58.encode(data.slice(offset, offset + 32))
-            authorizedSigners.push(signer)
-            offset += 32
-        }
-
-        return { authority, authorizedSigners }
-    }
-
-    // The rest of the Lit Action code...
-}
-```
-
-The `parseCredentialAccount` function deserializes the raw bytes returned from the Solana RPC into a readable credential account structure. It manually parses the binary data by reading specific byte offsets that correspond to the on-chain account layout: skipping the discriminator, extracting the authority public key, reading the name length and skipping those bytes, then finally extracting the list of authorized signers. This parsing is necessary because Solana stores account data as raw bytes, and we need to extract the authorized signers list to verify if the requesting signer has permission to decrypt the attestation data.
-
-##### Recreating the SIWS Message
-
-```ts
-const _litActionCode = async () => {
-    // Previous Lit Action code...
-
-    function getSiwsMessage(siwsInput) {
-        console.log('Attempting to parse SIWS message: ', siwsInput)
-
-        if (!siwsInput.domain || !siwsInput.address) {
-            throw new Error('Domain and address are required for Siws message construction')
-        }
-
-        // Start with the mandatory domain and address line
-        let message = `${siwsInput.domain} wants you to sign in with your Solana account:\n${siwsInput.address}`
-
-        // Add statement if provided (with double newline separator)
-        if (siwsInput.statement) {
-            message += `\n\n${siwsInput.statement}`
-        }
-
-        // Collect advanced fields in the correct order as per ABNF spec
-        const fields = []
-
-        if (siwsInput.uri) {
-            fields.push(`URI: ${siwsInput.uri}`)
-        }
-        if (siwsInput.version) {
-            fields.push(`Version: ${siwsInput.version}`)
-        }
-        if (siwsInput.chainId) {
-            fields.push(`Chain ID: ${siwsInput.chainId}`)
-        }
-        if (siwsInput.nonce) {
-            fields.push(`Nonce: ${siwsInput.nonce}`)
-        }
-        if (siwsInput.issuedAt) {
-            fields.push(`Issued At: ${siwsInput.issuedAt}`)
-        }
-        if (siwsInput.expirationTime) {
-            fields.push(`Expiration Time: ${siwsInput.expirationTime}`)
-        }
-        if (siwsInput.notBefore) {
-            fields.push(`Not Before: ${siwsInput.notBefore}`)
-        }
-        if (siwsInput.requestId) {
-            fields.push(`Request ID: ${siwsInput.requestId}`)
-        }
-        if (siwsInput.resources && siwsInput.resources.length > 0) {
-            fields.push(`Resources:`)
-            for (const resource of siwsInput.resources) {
-                fields.push(`- ${resource}`)
-            }
-        }
-
-        // Add advanced fields if any exist (with double newline separator)
-        if (fields.length > 0) {
-            message += `\n\n${fields.join('\n')}`
-        }
-
-        return message
-    }
-
-    // The rest of the Lit Action code...
-}
-```
-
-The `getSiwsMessage` function reconstructs the SIWS message string from the JSON input provided as `siwsMessage` in the [`jsParams` Lit Action parameter](#jsparams) within the secure Lit Action environment. This reconstruction is a critical security step that avoids trusting the message string passed as input (which could be manipulated), and instead rebuilds the message from its individual components according to Phantom's SIWS specification. This ensures the message structure matches what was originally signed by the user.
-
-##### Validating the SIWS Message
-
-```ts
-const _litActionCode = async () => {
-    // Previous Lit Action code...
-
-    function validateSiwsMessage(siwsInput) {
-        const now = new Date()
-
-        // Check if message has expired (expirationTime is in the past)
-        if (siwsInput.expirationTime) {
-            const expirationTime = new Date(siwsInput.expirationTime)
-            if (now > expirationTime) {
-                return {
-                    valid: false,
-                    error: `SIWS message has expired. Current time: ${now.toISOString()}, Expiration: ${siwsInput.expirationTime}`,
-                }
-            }
-        }
-
-        // Check if message is not yet valid (notBefore is in the future)
-        if (siwsInput.notBefore) {
-            const notBefore = new Date(siwsInput.notBefore)
-            if (now < notBefore) {
-                return {
-                    valid: false,
-                    error: `SIWS message is not yet valid. Current time: ${now.toISOString()}, Not Before: ${siwsInput.notBefore}`,
-                }
-            }
-        }
-
-        return { valid: true }
-    }
-
-    // The rest of the Lit Action code...
-}
-```
-
-The `validateSiwsMessage` function performs time-based validation on the SIWS message to prevent replay attacks and ensure the authentication request is fresh. It checks two optional time constraints: the `expirationTime` field to ensure the message hasn't expired, and the `notBefore` field to ensure the message isn't being used before its intended validity period.
-
-##### Verifying the SIWS Signature
-
-```ts
-const _litActionCode = async () => {
-    // Previous Lit Action code...
-
-    async function verifySiwsSignature(siwsMessage, signerAddress, siwsMessageSignature) {
-        try {
-            const publicKey = await crypto.subtle.importKey(
-                'raw',
-                ethers.utils.base58.decode(signerAddress),
-                {
-                    name: 'Ed25519',
-                    namedCurve: 'Ed25519',
-                },
-                false,
-                ['verify']
-            )
-
-            const isValid = await crypto.subtle.verify(
-                'Ed25519',
-                publicKey,
-                ethers.utils.base58.decode(siwsMessageSignature),
-                new TextEncoder().encode(siwsMessage)
-            )
-
-            return isValid
-        } catch (error) {
-            console.error('Error in verifySiwsSignature:', error)
-            throw error
-        }
-    }
-
-    // The rest of the Lit Action code...
-}
-```
-
-The `verifySiwsSignature` function performs cryptographic verification to confirm the SIWS message was actually signed by the claimed wallet address. It uses the Web Crypto API to import the public key from the Solana address (converting from Base58 format), then verifies the Ed25519 signature against the reconstructed message string. This cryptographic proof ensures that only someone with the private key corresponding to the claimed address could have created the signature, preventing impersonation attacks where malicious users might try to claim they control a wallet they don't actually own.
-
-##### Putting It All Together
-
-Now that we've covered the individual functions that make up the Lit Action code, let's put it all together to perform the SIWS message validation, and check if the message signer is authorized to decrypt the attestation data.
-
-The first steps is to parse the SIWS message into a JSON object, and reconstruct the SIWS message from the input parameters: `siwsMessage` to ensure the message is valid and not expired, or being used before its intended validity period:
-
-```ts
-const _litActionCode = async () => {
-    // Previous Lit Action code...
-
-    const siwsMessageJson = JSON.parse(siwsMessage)
-    const siwsMessageString = getSiwsMessage(siwsMessageJson)
-
-    try {
-        const siwsMessageValid = validateSiwsMessage(siwsMessageJson)
-        if (!siwsMessageValid.valid) {
-            console.log('SIWS message validation failed:', siwsMessageValid.error)
-            return LitActions.setResponse({
-                response: JSON.stringify({
-                    success: false,
-                    message: 'SIWS message validation failed.',
-                    error: siwsMessageValid.error,
-                }),
-            })
-        }
-    } catch (error) {
-        console.error('Error in validateSiwsMessage:', error)
-        return LitActions.setResponse({
-            response: JSON.stringify({
-                success: false,
-                message: 'Error in validateSiwsMessage.',
-                error: error.toString(),
-            }),
-        })
-    }
-
-    // The rest of the Lit Action code...
-}
-```
-
-Next, we'll verify the SIWS signature to ensure the message was actually signed by the claimed wallet address:
-
-```ts
-const _litActionCode = async () => {
-    // Previous Lit Action code...
-
-    try {
-        const siwsSignatureValid = await verifySiwsSignature(siwsMessageString, siwsMessageJson.address, siwsMessageSignature)
-
-        if (!siwsSignatureValid) {
-            console.log('Signature is invalid.')
-            return LitActions.setResponse({
-                response: JSON.stringify({
-                    success: false,
-                    message: 'Signature is invalid.',
-                }),
-            })
-        }
-
-        console.log('Signature is valid.')
-    } catch (error) {
-        console.error('Error verifying signature:', error)
-        return LitActions.setResponse({
-            response: JSON.stringify({
-                success: false,
-                message: 'Error verifying signature.',
-                error: error.toString(),
-            }),
-        })
-    }
-
-    // The rest of the Lit Action code...
-}
-```
-
-Then we perform the authorization check by fetching the hardcoded Credential account from Solana to verify decryption permissions. This involves a multi-step security validation:
-
-1. We confirm the credential account is owned by the legitimate Solana Attestation Service program (preventing attacks using fake credential accounts).
-2. We parse the account data to extract the authorized signers list.
-3. We verify that the authenticated wallet address from our SIWS message is actually included in this list of permitted decryption signers.
-
-```ts
-const _litActionCode = async () => {
-    // Previous Lit Action code...
-
-    // Fetch and verify authorized signers from the hardcoded credential
-    try {
-        const accountInfo = await fetchAccountData(AUTHORIZED_RPC_URL, AUTHORIZED_CREDENTIAL_PDA)
-
-        // Verify the credential account is owned by the correct program
-        if (accountInfo.owner !== AUTHORIZED_PROGRAM_ID) {
-            console.log(`Credential PDA owner mismatch. Expected: ${AUTHORIZED_PROGRAM_ID}, Got: ${accountInfo.owner}`)
-            return LitActions.setResponse({
-                response: JSON.stringify({
-                    success: false,
-                    message: 'Credential PDA is not owned by the authorized program',
-                    expectedOwner: AUTHORIZED_PROGRAM_ID,
-                    actualOwner: accountInfo.owner,
-                }),
-            })
-        }
-
-        const credential = parseCredentialAccount(accountInfo.data)
-
-        // Check if the signer is authorized
-        const signerAddress = siwsMessageJson.address
-        if (!credential.authorizedSigners.includes(signerAddress)) {
-            console.log(`Signer ${signerAddress} is not in authorized signers list`)
-            return LitActions.setResponse({
-                response: JSON.stringify({
-                    success: false,
-                    message: 'Signer is not authorized to decrypt',
-                    authorizedSigners: credential.authorizedSigners,
-                    requestingSigner: signerAddress,
-                }),
-            })
-        }
-
-        console.log(`Signer ${signerAddress} is authorized to decrypt`)
-    } catch (error) {
-        console.error('Error checking authorized signers:', error)
-        return LitActions.setResponse({
-            response: JSON.stringify({
-                success: false,
-                message: 'Error checking authorized signers',
-                error: error.toString(),
-            }),
-        })
-    }
-
-    // The rest of the Lit Action code...
-}
-```
-
-Lastly, after validating the signer of the SIWS message is authorized to decrypt the attestation data, we can proceed to decrypt the attestation data using `Lit.Actions.decryptAndCombine`:
-
-```ts
-const _litActionCode = async () => {
-    // Previous Lit Action code...
-
-    try {
-        const decryptedData = await Lit.Actions.decryptAndCombine({
-            accessControlConditions: [
-                {
-                    method: '',
-                    params: [':currentActionIpfsId'],
-                    pdaParams: [],
-                    pdaInterface: { offset: 0, fields: {} },
-                    pdaKey: '',
-                    chain: 'solana',
-                    returnValueTest: {
-                        key: '',
-                        comparator: '=',
-                        value: LitAuth.actionIpfsIds[0],
-                    },
-                },
-            ],
-            ciphertext,
-            dataToEncryptHash,
-            authSig: {
-                sig: ethers.utils.hexlify(ethers.utils.base58.decode(siwsMessageSignature)).slice(2),
-                derivedVia: 'solana.signMessage',
-                signedMessage: siwsMessageString,
-                address: siwsMessageJson.address,
-            },
-            chain: 'solana',
-        })
-        return LitActions.setResponse({ response: JSON.stringify({ success: true, decryptedData }) })
-    } catch (error) {
-        console.error('Error decrypting data:', error)
-        return LitActions.setResponse({
-            response: JSON.stringify({
-                success: false,
-                message: 'Error decrypting data.',
-                error: error.toString(),
-            }),
-        })
-    }
-
-    // The rest of the Lit Action code...
-}
-```
-
-The `Lit.Actions.decryptAndCombine` function is part of the Lit Actions SDK and is available globally within the Lit node execution environment. When invoked, it initiates the distributed decryption process across the Lit network. Each participating Lit node checks whether the provided Access Control Conditions are satisfied, and if so, generates and shares its decryption share with the network. Once enough valid shares are collected (2/3 of the total Lit nodes), they are combined to reconstruct the decrypted data, which is then returned to the Lit Action.
-
-The parameters for `Lit.Actions.decryptAndCombine` are:
-
-- `accessControlConditions`: An array of Access Control Conditions that must be satisfied for the decryption to occur.
-- `ciphertext`: The ciphertext to decrypt that we fetched from the on-chain Attestation account.
-- `dataToEncryptHash`: The hash of the data to encrypt that we fetched from the on-chain Attestation account.
-- `authSig`: The signature of the SIWS message used by the Lit nodes to authenticate who's making the decryption request.
-- `chain`: The chain corresponding to the `authSig` parameter (in this case, `solana` because we're providing a signature using a Solana keypair).
-
-For a refresher on how the `accessControlConditions` parameter works, check out the [Access Control Conditions](#access-control-conditions) section we covered earlier.
-
-## Implementation
-
-Now that we've setup and covered all the parts of this demo, let's run it!
-
-The following demonstation script follows the same pattern as the [Basic Attestation Flow](/guides/ts/lit-encrypted-attestations/basic-attestation-flow) guide, but with some changes that demonstrate how to use the helper functions we created above to encrypt the attestation data.
-
-### Prerequisites
-
-- As [mentioned earlier](#running-the-generate-credential-pda-script), make sure to run the `generate-credential-pda` script to create the Issuer and Authorized Signers keypairs, as well as derive the Credential PDA.
-- Copy and paste the Credential PDA from the output of the script into the `AUTHORIZED_CREDENTIAL_PDA` variable in Lit Action (see [here](#hardcoded-credential-account) for more details).
+The line: `Credential PDA: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk` is important and what we'll need to hardcode into our decryption Lit Action for the `AUTHORIZED_CREDENTIAL_PDA` constant.
 
 ### Step 1: Setup
 
@@ -1761,7 +279,7 @@ async function main() {
 
     // Step 3: Setting up Credential
 
-    // Step 4: Createing Schema
+    // Step 4: Creating Schema
 
     // Step 5: Creating Attestation
 
@@ -1780,6 +298,36 @@ The current code includes spaces for 8 steps. We've started by creating our clie
 This step is creating our Lit node client, connecting us to the Lit Datil-dev network. Additionally, the Ethereum wallet we'll be using as the payer for the decryption request is generated and returned to us. Add the following code to your `main` function after Step 1:
 
 _Note: remeber that while using the Lit Datil-dev network, payment is actually required, but providing a wallet is still required._
+
+Create the file `setup-lit.ts` in our `lit` helpers directory and export the function `setupLit`:
+
+```ts
+import { LIT_NETWORK, LIT_RPC } from '@lit-protocol/constants'
+import { LitNodeClient } from '@lit-protocol/lit-node-client'
+import { LIT_NETWORKS_KEYS } from '@lit-protocol/types'
+import { ethers } from 'ethers'
+
+export async function setupLit({
+    litNetwork = LIT_NETWORK.DatilDev,
+    debug = false,
+}: {
+    litNetwork?: LIT_NETWORKS_KEYS
+    debug?: boolean
+} = {}) {
+    const litPayerEthersWallet = new ethers.Wallet(ethers.Wallet.createRandom().privateKey, new ethers.providers.JsonRpcProvider(LIT_RPC.CHRONICLE_YELLOWSTONE))
+
+    const litNodeClient = new LitNodeClient({
+        litNetwork,
+        debug,
+    })
+    await litNodeClient.connect()
+
+    return {
+        litNodeClient,
+        litPayerEthersWallet,
+    }
+}
+```
 
 ```ts
 // Step 2: Setup Lit
@@ -1872,11 +420,54 @@ try {
 
 Next, we need to issue an actual attestation to a specific user with the defined data and expiration.
 
-Because we're encrypting our attestation data, we need to first encrypt it using our `encryptAttestationData` helper function, and then create the attestation using the encryption metadata.
+Because we're encrypting our attestation data, we need to first encrypt it using Lit Protocol, and then create the attestation using the encryption metadata.
 
-Add the following code to your `main` function after Step 4:
+Create the file `encrypt-attestation-data.ts` in our `lit` helpers directory and export the function `encryptAttestationData`:
 
 ```ts
+import { LitNodeClient } from '@lit-protocol/lit-node-client'
+import ipfsOnlyHash from 'typestub-ipfs-only-hash'
+
+import { AttestationEncryptionMetadata } from '../types'
+import { litActionCode as litActionCodeDecrypt } from '../litActionDecrypt'
+
+export const encryptAttestationData = async ({
+    litNodeClient,
+    attestationData,
+}: {
+    litNodeClient: LitNodeClient
+    attestationData: Uint8Array
+}): Promise<AttestationEncryptionMetadata> => {
+    const { ciphertext, dataToEncryptHash } = await litNodeClient.encrypt({
+        dataToEncrypt: attestationData,
+        solRpcConditions: [
+            {
+                method: '',
+                params: [':currentActionIpfsId'],
+                pdaParams: [],
+                pdaInterface: { offset: 0, fields: {} },
+                pdaKey: '',
+                chain: 'solana',
+                returnValueTest: {
+                    key: '',
+                    comparator: '=',
+                    value: await ipfsOnlyHash.of(litActionCodeDecrypt),
+                },
+            },
+        ],
+        // @ts-ignore
+        chain: 'solana',
+    })
+
+    return { ciphertext, dataToEncryptHash }
+}
+```
+
+After creating the helper, import it and add the following code to your `main` function after Step 4:
+
+```ts
+import { encryptAttestationData } from './lit-helpers/encrypt-attestation-data'
+
 // Step 5: Create and Encrypt Attestation
 console.log('\n5. Creating Attestation...')
 const [attestationPda] = await deriveAttestationPda({
@@ -2095,6 +686,20 @@ main()
 
 To test your attestation workflow, run the script in your project terminal:
 
+:::note
+In order to run the demonstration using the following command, make sure you're `package.json` contains the following:
+
+```json
+"scripts": {
+  "start": "ts-node attestation-demo.ts",
+  "build": "tsc"
+}
+```
+
+If you've copied the existing `attestation-demo.ts` file and renamed it for this encryption code example, make sure you use the new file name here in the `start` script.
+
+:::
+
 :::code-group
 
 ```bash [npm]
@@ -2113,7 +718,7 @@ yarn start
 
 Here's what you should expect to see in the output:
 
-```
+```bash
 lit-js-sdk:constants:errors deprecated LitErrorKind is deprecated and will be removed in a future version. Use LIT_ERROR_KIND instead. node:internal/modules/cjs/loader:1692:14
 Starting Solana Attestation Service with Lit Protocol encrypted attestation demo
 

--- a/docs/pages/guides/ts/lit-encrypted-attestations/basic-attestation-flow.mdx
+++ b/docs/pages/guides/ts/lit-encrypted-attestations/basic-attestation-flow.mdx
@@ -1,0 +1,1258 @@
+---
+title: Encrypted Attestation Data with Lit Protocol
+description: Learn how to encrypt and control access to attestation data using Lit Protocol's decentralized key management network
+date: 2025-08-12
+---
+
+# Encrypted Attestation Data with Lit Protocol
+
+## Introduction
+
+When creating attestations on Solana, you may need to handle sensitive data that shouldn't be publicly visible on-chain. While blockchain provides transparency and immutability, certain attestation use cases require privacy controls - such as medical records, academic transcripts, or confidential business certifications.
+
+This guide demonstrates how to create **encrypted attestations** by combining Solana's attestation capabilities with [Lit Protocol](https://litprotocol.com), a decentralized key management network that enables secure encryption and programmable access control.
+
+### Why Lit Protocol?
+
+Lit Protocol provides a decentralized key management network that solves Web3's security dilemma: how to manage secrets without trusting centralized servers or burdening users with complex key management.
+
+#### Identity-Based Encryption Architecture
+
+Each Lit node runs in a Trusted Execution Environment (TEE) powered by sealed AMD SEV-SNP hardware that isolates key material from node operators.
+
+Lit's encryption uses Identity-Based Encryption with BLS signatures:
+
+1. **Network BLS key generation**: Participating Lit nodes collectively generate a network wide BLS public/private key pair using Distributed Key Generation (DKG)
+2. **Encryption process**: Data is encrypted using the network's BLS public key, with your access control conditions serving as the "identity"
+3. **Decryption policy**: The access control conditions (like wallet ownership, token holdings, or custom logic) become the identity that must be proven for decryption
+
+#### Threshold Decryption Process
+
+To decrypt data, a threshold of more than two-thirds of Lit nodes must collaborate, each providing a BLS signature share:
+
+1. **Policy verification**: Each node independently verifies that your access control conditions are met (checking on-chain state, signatures, etc.)
+2. **Signature share creation**: If conditions are satisfied, each node uses their BLS private key share to sign the identity (your access control policy)
+3. **Threshold reconstruction**: Once enough signature shares are collected, they're combined to create the complete BLS signature
+4. **Data decryption**: The reconstructed BLS signature serves as the decryption key to decrypt your ciphertext
+
+This Identity-Based Encryption approach ensures that decryption keys are generated on-demand only when authorization conditions are met, with no pre-shared secrets or centralized key storage.
+
+## Getting Started
+
+This guide will walk you through creating a complete encrypted attestation script that:
+
+- Creates credential and schema accounts on Solana
+- Encrypts sensitive attestation data using Lit Protocol's decentralized network
+- Stores the encrypted metadata on-chain, keeping the attestation data private
+- Implements SIWS (Sign In With Solana) authentication for decryption using Lit's Identity-Based Encryption, ensuring that only authorized signers can decrypt attestation data
+- Verifies attestations for both attested and non-attested users
+- Verifies that only authorized signers can decrypt attestation data
+- Closes an attestation (effectively revoking a user's credential)
+
+The end goal will be to see a working attestation system in action:
+
+```shell
+================================================================================
+SOLANA ATTESTATION SERVICE WITH LIT PROTOCOL ENCRYPTED ATTESTATION DEMO
+================================================================================
+
+📋 DEMO CONFIGURATION:
+   Network: localnet
+   Organization: LIT-ENCRYPTED-ATTESTATIONS
+   Schema: LIT-ENCRYPTED-METADATA (v1)
+
+🔑 CREATED ACCOUNTS:
+   Credential PDA:    HhU8FzCALX7XThBoPUQnJWAZMJdDeXctdxbedbT4kshV
+   Schema PDA:        HvLgB2BjQN3BzjQszYw6xuCCMpWPEkfs4b1YMrRBEp7H
+   Attestation PDA:   41Tx4apNq6tocjY4FK4QXpZoTeybaPo1hK328SwvpLRf
+   Test User:         JCRGgpTgaun9581uounx61RSmiMxN8KazEjdCnJbBdwB
+
+🧪 VERIFICATION TEST RESULTS:
+   Test User Verification:     ✅ PASSED
+   Encrypted Metadata:
+     - Ciphertext: plYShVUjPEdl69jWh54tjutxcBEjx7GiCYH1KKfnowhqUWOPkH...
+     - Data Hash: 4efa888818ad5ba81b0e459037eb8c62a3f0bdf401de5372e21d8aa132a0a808
+   Decrypted Attestation Data: {"name":"test-user","age":100,"country":"usa"}
+   Random User Verification:   ✅ PASSED (correctly rejected)
+   Unauthorized Signer Test:   ✅ PASSED (correctly rejected)
+   ✅ ALL TESTS PASSED! Demo completed successfully.
+
+================================================================================
+```
+
+### Prerequisites
+
+Before starting this guide, you should have:
+
+- [**Node.js**](https://nodejs.org/en/download) (v22 or later)
+- [**Solana CLI**](https://solana.com/docs/intro/installation) v 2.2.x or greater
+- [TypeScript](http://typescriptlang.org/) Experience
+
+Additionally, this guide builds on top of the [Basic Solana Attestation Flow](/guides/ts/how-to-create-digital-credentials) guide, so you should have a working implementation of that guide to add to before starting this one.
+
+## Understanding Lit Encryption
+
+To effectively use Lit Protocol for encrypted attestations, it's important to understand the key components and how they work together to provide secure, programmable access control.
+
+### Lit Actions
+
+Lit Actions are JavaScript programs that run inside the secure hardware (TEEs) of Lit nodes across the decentralized Lit Protocol network.
+
+They are similar to smart contracts, but can interact with both on-chain and off-chain data to perform complex authorization logic.
+
+Each Lit node independently executes the same Lit Action in isolation, and more than two-thirds of nodes must agree on the result for consensus. This allows Lit Actions to securely:
+
+- Fetch data from external APIs (like Solana RPC endpoints).
+- Perform complex authorization logic.
+- Only authorize decryption when specific conditions are met.
+
+The Lit Action for this attestation demo acts as an authorization gatekeeper for decryption. It performs four key checks:
+
+1. **SIWS Authentication**: Validates the SIWS message, ensuring correct format, unexpired timestamp, and a valid signature from the claimed wallet.
+2. **Credential Verification**: Fetches the credential account from Solana, confirming its existence, correct program ownership, and data integrity.
+3. **Authorization**: Checks if the SIWS wallet address is listed as an authorized signer in the credential.
+4. **Conditional Decryption**: Only if all checks pass, the Lit Action decrypts and returns the attestation data; otherwise, access is denied.
+
+This ensures only explicitly authorized wallets can decrypt attestation data.
+
+### Access Control Conditions
+
+Access Control Conditions (ACCs) are the rules that determine who can decrypt your data, and under what circumstances. The Lit network will only allow decryption if these specific conditions are met.
+
+For this attestation demo, the ACCs are structured as:
+
+```typescript
+import ipfsOnlyHash from 'typestub-ipfs-only-hash'
+
+// This is the custom Lit Action created for this demo,
+// we'll be diving into it's implementation later in this guide
+import { litActionCode as litActionCodeDecrypt } from '../litActionDecrypt'
+
+const accessControlConditions = [
+    {
+        method: '',
+        params: [':currentActionIpfsId'],
+        pdaParams: [],
+        pdaInterface: { offset: 0, fields: {} },
+        pdaKey: '',
+        chain: 'solana',
+        returnValueTest: {
+            key: '',
+            comparator: '=',
+            value: await ipfsOnlyHash.of(litActionCodeDecrypt),
+        },
+    },
+]
+```
+
+Let's break down what each field means:
+
+- `params: [':currentActionIpfsId']`: A special parameter that gets the [IPFS CID](https://docs.ipfs.tech/concepts/content-addressing/) of the currently executing Lit Action
+- `chain: 'solana'`: Tells Lit Protocol this condition involves the Solana blockchain
+- `returnValueTest`: The authorization logic that must be satisfied for decryption to be permitted
+    - `comparator: '='`: The boolean operator used for comparison
+    - `value: await ipfsOnlyHash.of(litActionCodeDecrypt)`: The IPFS CID of our specific custom Lit Action for decryption
+
+This ACC is essentially saying:
+
+> "Only allow decryption if the request is coming from the Lit Action we specifically designed for authorizing attestation decryption."
+
+Since the Lit Action contains all the business logic for checking SIWS authentication and Solana credential authorization, this ACC ensures only authorized signers of the Solana credential can decrypt the attestation data.
+
+### Encryption Metadata
+
+When Lit encrypts your attestation data, it returns two crucial pieces of metadata that are required for decryption:
+
+- `ciphertext`: This is the actual encrypted version of your sensitive attestation data.
+- `dataToEncryptHash`: A cryptographic hash of the original data and the ACCs used to encrypted the data.
+
+## Project Setup
+
+_Prefer to jump straight to the code? Check out our [Examples Repo on GitHub](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript/attestation-flow-guides/src/lit/sas-standard-lit-demo.ts) for the complete code for this guide\!_
+
+As mentioned above, this guide builds on top of the [Basic Solana Attestation Flow](/guides/ts/how-to-create-digital-credentials) guide, so make sure you have a working implementation of that guide to add to before continuing with this one.
+
+Let's start by adding the necessary dependencies to encrypt our attestation data with Lit:
+
+:::code-group
+
+```bash [npm]
+npm init -y
+npm i \
+    @lit-protocol/auth-helpers \
+    @lit-protocol/constants \
+    @lit-protocol/lit-node-client \
+npm i --save-dev @lit-protocol/types
+```
+
+```bash [pnpm]
+pnpm init
+pnpm i \
+    @lit-protocol/auth-helpers \
+    @lit-protocol/constants \
+    @lit-protocol/lit-node-client \
+pnpm i -D @lit-protocol/types
+```
+
+```bash [yarn]
+yarn init -y
+yarn add \
+    @lit-protocol/auth-helpers \
+    @lit-protocol/constants \
+    @lit-protocol/lit-node-client \
+yarn add -D @lit-protocol/types
+```
+
+Within your existing `solana-attestation-demo` directory, create a `lit` directory we can use to store our Lit related files:
+
+```bash
+mkdir lit
+```
+
+### Creating a Types file
+
+We'll cover each of the following types as we use them in this guide, but for now, let's create a `types.ts` file that will contain the types we'll be using:
+
+```ts
+/**
+ * Sign-in With Solana (Siws) messages (following Phantom's specification)
+ * https://github.com/phantom/sign-in-with-solana/tree/main
+ */
+export interface SiwsMessage {
+    /**
+     * Optional EIP-4361 domain requesting the sign-in.
+     * If not provided, the wallet must determine the domain to include in the message.
+     */
+    domain?: string
+    /**
+     * Optional Solana address performing the sign-in. The address is case-sensitive.
+     * If not provided, the wallet must determine the Address to include in the message.
+     */
+    address?: string
+    /**
+     * Optional EIP-4361 Statement. The statement is a human readable string and should not have new-line characters (\n).
+     * If not provided, the wallet must not include Statement in the message.
+     */
+    statement?: string
+    /**
+     * Optional EIP-4361 URI. The URL that is requesting the sign-in.
+     * If not provided, the wallet must not include URI in the message.
+     */
+    uri?: string
+    /**
+     * Optional EIP-4361 version.
+     * If not provided, the wallet must not include Version in the message.
+     */
+    version?: string
+    /**
+     * Optional EIP-4361 Chain ID.
+     * The chainId can be one of the following: mainnet, testnet, devnet, localnet, solana:mainnet, solana:testnet, solana:devnet.
+     * If not provided, the wallet must not include Chain ID in the message.
+     */
+    chainId?: string
+    /**
+     * Optional EIP-4361 Nonce.
+     * It should be an alphanumeric string containing a minimum of 8 characters.
+     * If not provided, the wallet must not include Nonce in the message.
+     */
+    nonce?: string
+    /**
+     * Optional ISO 8601 datetime string.
+     * This represents the time at which the sign-in request was issued to the wallet.
+     * Note: For Phantom, issuedAt has a threshold and it should be within +/- 10 minutes from the timestamp at which verification is taking place.
+     * If not provided, the wallet must not include Issued At in the message.
+     */
+    issuedAt?: string
+    /**
+     * Optional ISO 8601 datetime string.
+     * This represents the time at which the sign-in request should expire.
+     * If not provided, the wallet must not include Expiration Time in the message.
+     */
+    expirationTime?: string
+    /**
+     * Optional ISO 8601 datetime string.
+     * This represents the time at which the sign-in request becomes valid.
+     * If not provided, the wallet must not include Not Before in the message.
+     */
+    notBefore?: string
+    /**
+     * Optional EIP-4361 Request ID.
+     * In addition to using nonce to avoid replay attacks, dapps can also choose to include a unique signature in the requestId.
+     * Once the wallet returns the signed message, dapps can then verify this signature against the state to add an additional, strong layer of security.
+     * If not provided, the wallet must not include Request ID in the message.
+     */
+    requestId?: string
+    /**
+     * Optional EIP-4361 Resources.
+     * Usually a list of references in the form of URIs that the dapp wants the user to be aware of.
+     * These URIs should be separated by \n-, i.e., URIs in new lines starting with the character '-'.
+     * If not provided, the wallet must not include Resources in the message.
+     */
+    resources?: string[]
+}
+
+/**
+ * Type-safe Siws message for formatting - requires mandatory fields domain and address
+ */
+export interface SiwsMessageForFormatting extends SiwsMessage {
+    domain: string // Required for message construction
+    address: string // Required for message construction
+}
+
+/**
+ * Input for createSiwsMessage - requires address, all other fields optional
+ */
+export interface SiwsMessageInput extends Partial<SiwsMessage> {
+    address: string // Address is mandatory for creation
+}
+
+export interface AttestationEncryptionMetadata {
+    ciphertext: string
+    dataToEncryptHash: string
+}
+
+export interface PkpInfo {
+    ethAddress: string
+    publicKey: string
+    tokenId: string
+}
+
+export interface LitDecryptionResponse {
+    success: boolean
+    message: string
+    error?: string
+    authorizedSigners?: string[]
+    requestingSigner?: string
+    decryptedData?: string
+}
+```
+
+## Updating the Existing Attestation Implementation
+
+Let's update the existing file, `attestation-demo.ts`, as well as create our Lit related files that allow us to encrypted our attestation data:
+
+### Imports and Configuration
+
+Start with the adding necessary imports:
+
+_Add these dependencies to the existing ones from the Basic Solana Attestation Flow guide._
+
+```ts
+import type { LitNodeClient } from '@lit-protocol/lit-node-client'
+import { fetchCredential } from 'sas-lib'
+import { KeyPairSigner } from 'gill'
+import { ethers } from 'ethers'
+```
+
+Next, update the existing configuration:
+
+```ts
+const CONFIG = {
+    CLUSTER_OR_RPC: 'devnet',
+    CREDENTIAL_NAME: 'LIT-ENCRYPTED-ATTESTATIONS',
+    SCHEMA_NAME: 'LIT-ENCRYPTED-METADATA',
+    SCHEMA_LAYOUT: Buffer.from([12, 12]),
+    SCHEMA_FIELDS: ['ciphertext', 'dataToEncryptHash'],
+    SCHEMA_VERSION: 1,
+    SCHEMA_DESCRIPTION: 'Schema for Lit Protocol encrypted attestation metadata with access control conditions',
+    ATTESTATION_DATA: {
+        name: 'test-user',
+        age: 100,
+        country: 'usa',
+    },
+    ATTESTATION_EXPIRY_DAYS: 365,
+}
+```
+
+Previously, the configuration's `SCHEMA_FIELDS` specified the individual properties of the attestation data. However, now that we'll be encrypting the attestation data, the schema defines the Lit encryption metadata (`ciphertext` and `dataToEncryptHash`) that will be stored on-chain instead, and used for decryption.
+
+For this example, the `SCHEMA_LAYOUT` is set to `Buffer.from([12, 12])` which corresponds to two fields:
+
+- the first `12` represents a String type for the `ciphertext` field,
+- the second `12` represents a String type for the `dataToEncryptHash` field.
+
+### Utility Functions
+
+Next, we're going to make some modifications to the existing `setupWallets` helper function. Instead of generating new keypairs for `authorizedSigner1`, `authorizedSigner2`, and `issuer` every time we run the script, we're going to generate them once and same them to a keyfile.
+
+This is because we need to have a static and predetermined Credential PDA address that will be hardcoded within our Lit Action that handles the authorization checks and decryption. Hardcoding the Credential PDA allows the Lit Action to enforce that only authorized signers for the specific Credential are authorized to decrypt the attestation data.
+
+#### Creating the Authorized Signer and Issuer Keypairs
+
+Let's start by creating a new `get-keypair.ts` file that will handle generating new keypairs, saving them to a keyfile, and loading them from the keyfile:
+
+```ts
+import { existsSync, mkdirSync } from 'fs'
+import { generateExtractableKeyPairSigner } from 'gill'
+import { loadKeypairSignerFromFile, saveKeypairSignerToFile } from 'gill/node'
+import path from 'path'
+
+async function generateKeypair(outputPath: string) {
+    const extractableSigner = await generateExtractableKeyPairSigner()
+    await saveKeypairSignerToFile(extractableSigner, outputPath)
+}
+
+async function getKeyPair(keyPairName: string) {
+    const keyPairDir = 'key-pairs'
+    const keyPairPath = path.join(keyPairDir, `${keyPairName}.keypair.json`)
+    if (!existsSync(keyPairPath)) {
+        // Ensure the directory exists before creating the file
+        if (!existsSync(keyPairDir)) {
+            mkdirSync(keyPairDir, { recursive: true })
+        }
+        console.log(`${keyPairName} keypair does not exist at path: ${keyPairPath}. Generating it...`)
+        await generateKeypair(keyPairPath)
+    }
+
+    return loadKeypairSignerFromFile(keyPairPath)
+}
+
+export async function getIssuerKeypair() {
+    const keypair = await getKeyPair('issuer')
+    console.log(`Got Issuer keypair with address: ${keypair.address}`)
+    return keypair
+}
+
+export async function getAuthorizedSigner1Keypair() {
+    const keypair = await getKeyPair('authorized-signer-1')
+    console.log(`Got Authorized Signer 1 keypair with address: ${keypair.address}`)
+    return keypair
+}
+
+export async function getAuthorizedSigner2Keypair() {
+    const keypair = await getKeyPair('authorized-signer-2')
+    console.log(`Got Authorized Signer 2 keypair with address: ${keypair.address}`)
+    return keypair
+}
+```
+
+#### Deriving the Credential PDA from the Issuer Keypair
+
+Next we'll create a new helper script called `generate-credential-pda.ts` that will generate a new or load an existing Issuer keypair, and use it to derive the Credential PDA address:
+
+```ts
+import { deriveCredentialPda } from 'sas-lib'
+
+import { getIssuerKeypair } from './get-keypair'
+
+async function main() {
+    console.log('Starting credential PDA generator\n')
+
+    // Step 1: Get issuer keypair
+    console.log('1. Getting Issuer keypair...')
+    const issuer = await getIssuerKeypair()
+
+    // Step 2: Create Credential
+    console.log('\n2. Creating Credential...')
+    const [credentialPda] = await deriveCredentialPda({
+        authority: issuer.address,
+        name: 'LIT-ENCRYPTED-METADATA',
+    })
+
+    console.log(`Credential PDA: ${credentialPda}`)
+}
+
+main()
+    .then(() => console.log('\nCredential PDA generated successfully!'))
+    .catch(error => {
+        console.error('❌ Failed to generate credential PDA:', error)
+        process.exit(1)
+    })
+```
+
+To run this helper script, we'll add a new script to our `package.json` file:
+
+```json
+"scripts": {
+  "generate-credential-pda": "ts-node src/lit/generate-credential-pda.ts",
+}
+```
+
+##### Running the Generate Credential PDA Script
+
+Before continuing with this guide, you'll need to run this script which will generate the Issuer keypair and Credential PDA, and save their keyfiles to a directory called `key-pairs`. After running the script, you should see output similar to:
+
+```bash
+pnpm generate-credential-pda
+
+> solana-attestation-demo-ts@1.0.0 generate-credential-pda attestation-flow-guides
+> ts-node src/lit/generate-credential-pda.ts
+
+Starting credential PDA generator
+
+1. Getting Issuer keypair...
+issuer keypair does not exist at path: key-pairs/issuer.keypair.json. Generating it...
+Got Issuer keypair with address: EFjEXBpSHL7xXUNZEQf5CKWD7dZHkLfqc1i9tceoqms2
+
+2. Creating Credential...
+Credential PDA: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
+
+Credential PDA generated successfully!
+```
+
+The line: `Credential PDA: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk` is important and what we'll need to hardcode into our Lit Action later in this guide.
+
+#### Updating the Setup Wallets Function
+
+Now that we have our keyfiles generated, and some helper functions to load them, we can update the `setupWallets` function to load the keypairs from the keyfiles instead of generating new ones every time.
+
+First add the import in the `attestation-demo.ts` file:
+
+```ts
+import { getAuthorizedSigner1Keypair, getAuthorizedSigner2Keypair, getIssuerKeypair } from './get-keypair'
+```
+
+Then update the `setupWallets` function to load the keypairs from the keyfiles:
+
+```ts
+async function setupWallets(client: SolanaClient) {
+    try {
+        const payer = await generateKeyPairSigner()
+        const authorizedSigner1 = await getAuthorizedSigner1Keypair() // <-- Load from keyfile using our helper function
+        const authorizedSigner2 = await getAuthorizedSigner2Keypair() // <-- Load from keyfile using our helper function
+        const issuer = await getIssuerKeypair() // <-- Load from keyfile using our helper function
+        const testUser = await generateKeyPairSigner()
+
+        const airdrop = airdropFactory({ rpc: client.rpc, rpcSubscriptions: client.rpcSubscriptions })
+        const airdropTx: Signature = await airdrop({
+            commitment: 'processed',
+            lamports: lamports(BigInt(1_000_000_000)),
+            recipientAddress: payer.address,
+        })
+
+        console.log(`    - Airdrop completed: ${airdropTx}`)
+        return { payer, authorizedSigner1, authorizedSigner2, issuer, testUser }
+    } catch (error) {
+        throw new Error(`Failed to setup wallets: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    }
+}
+```
+
+This is a key change to the existing Basic Solana Attestation Flow, and without it, we'll be unable to setup our Lit Action to properly authenticate Credential signers when they make requests to Lit to decrypt the attestation data.
+
+### Updating the Attestation Verification Function
+
+We'll be modifying the existing `verifyAttestation` function to handle retrieving the Lit encryption metadata from the on-chain attestation data, and decrypting by submitting a signed Sign-in-with-Solana (SIWS) message to our custom decryption Lit Action.
+
+_Make sure to add the following imports to the top of the file:_
+
+```ts
+import { createSiwsMessage, decryptAttestationData, signSiwsMessage } from './lit-helpers'
+import { AttestationEncryptionMetadata } from './types'
+```
+
+```ts
+async function verifyAttestation({
+    client,
+    schemaPda,
+    userAddress,
+    authorizedSigner,
+    litDecryptionParams,
+}: {
+    client: SolanaClient
+    schemaPda: Address
+    userAddress: Address
+    authorizedSigner: KeyPairSigner
+    litDecryptionParams: {
+        litNodeClient: LitNodeClient
+        litPayerEthersWallet: ethers.Wallet
+    }
+}): Promise<{ isVerified: boolean; decryptedAttestationData: string | null }> {
+    try {
+        const schema = await fetchSchema(client.rpc, schemaPda)
+        if (schema.data.isPaused) {
+            console.log(`    -  Schema is paused`)
+            return { isVerified: false, decryptedAttestationData: null }
+        }
+        const [attestationPda] = await deriveAttestationPda({
+            credential: schema.data.credential,
+            schema: schemaPda,
+            nonce: userAddress,
+        })
+        const attestation = await fetchAttestation(client.rpc, attestationPda)
+        const attestationData = deserializeAttestationData(schema.data, attestation.data.data as Uint8Array) as AttestationEncryptionMetadata
+        console.log(`    - Attestation data:`, attestationData)
+
+        let decryptedAttestationData: string | null = null
+        try {
+            const siwsMessage = createSiwsMessage({
+                address: authorizedSigner.address,
+                domain: 'localhost',
+                uri: 'http://localhost',
+                version: '1',
+            })
+            const siwsMessageSignature = await signSiwsMessage(siwsMessage, authorizedSigner)
+
+            decryptedAttestationData = (await decryptAttestationData({
+                ...litDecryptionParams,
+                ...attestationData,
+                siwsMessage,
+                siwsMessageSignature,
+            })) as string
+        } catch (error) {
+            console.error('There was an error while decrypting the attestation data:', error)
+            return { isVerified: false, decryptedAttestationData: null }
+        }
+
+        const currentTimestamp = BigInt(Math.floor(Date.now() / 1000))
+        return { isVerified: currentTimestamp < attestation.data.expiry, decryptedAttestationData }
+    } catch (error) {
+        return { isVerified: false, decryptedAttestationData: null }
+    }
+}
+```
+
+Let's cover the differences between the existing `verifyAttestation` function and the updated one:
+
+- New function parameters:
+    - `authorizedSigner`: This parameter is expected to be one of the Credential's Authorized Signer keypairs we loaded from the keyfiles.
+    - `litDecryptionParams`: This object contains a Lit Node Client and an Ethereum wallet (we'll dive deeper into why we need an Ehtereum wallet later in this guide) which allows us to make the decryption request to the Lit network.
+- New function return type:
+    - `decryptedAttestationData`: This is the decrypted attestation data returned from the Lit Action after the SIWS message is authenticated and verified by the Lit network.
+- New return value type for `deserializeAttestationData`:
+    - Previously, this function call returned the raw attestation data that was stored on-chain, but now it's returning `AttestationEncryptionMetadata` (as defined in our [`types.ts` file](#creating-a-types-file)) which is our Lit encryption metadata: `ciphertext` and `dataToEncryptHash`.
+
+#### Diving into the Decryption Process
+
+As a prerequisite to making the decryption request to the Lit network, we need to create and sign a SIWS message with one of the Credential's Authorized Signer keypairs.
+
+##### Creating the SIWS Message
+
+Let's create the file `create-siws-message.ts` in our `lit` helpers directory, and export the function `createSiwsMessage`:
+
+```ts
+import { SiwsMessageForFormatting, SiwsMessageInput } from '../types'
+
+/**
+ * Creates a complete Siws message by filling in missing properties with sensible defaults
+ * @param siws - Siws message object with required address field
+ * @returns Complete Siws message with all fields populated
+ */
+export function createSiwsMessage(siws: SiwsMessageInput): SiwsMessageForFormatting {
+    const now = new Date()
+    const expirationTime = new Date(now.getTime() + 10 * 60 * 1000) // 10 minutes
+
+    // Generate a proper nonce if not provided (minimum 8 characters, alphanumeric)
+    const generatedNonce = siws.nonce || Math.random().toString(36).substring(2, 12) // 10 character alphanumeric
+
+    // Merge siws with defaults, siws values take precedence
+    return {
+        domain: siws.domain || 'localhost',
+        address: siws.address,
+        statement: siws.statement || 'Sign this message to authenticate with Lit Protocol',
+        uri: siws.uri || 'http://localhost',
+        version: siws.version || '1',
+        chainId: siws.chainId || 'devnet', // Must be string as per Siws spec: mainnet, testnet, devnet, localnet, etc.
+        nonce: generatedNonce,
+        issuedAt: siws.issuedAt || now.toISOString(),
+        expirationTime: siws.expirationTime || expirationTime.toISOString(),
+        notBefore: siws.notBefore,
+        requestId: siws.requestId,
+        resources: siws.resources || [],
+    }
+}
+```
+
+_As with the rest of this guide, any imported custom types from the [`types.ts` file](#creating-a-types-file) we created previously._
+
+This helper function utilizes [Phantom's SIWS message specification](https://github.com/phantom/sign-in-with-solana/tree/main), and is used to prove the identity of a Credential signer to the Lit network. This SIWS message is part of the authorization process in our custom Lit Action that will gatekeep who is permitted to decrypt the attestation data.
+
+##### Signing the SIWS Message
+
+Going back to the `verifyAttestation` function, the next step after creating the SIWS message is to sign it with a Credential's Authorized Signer keypair. To do this we'll create the file `sign-siws-message.ts` in our `lit` helpers directory, and export the function `signSiwsMessage`:
+
+```ts
+import { ethers } from 'ethers'
+import { createSignableMessage, KeyPairSigner } from 'gill'
+
+import { SiwsMessageForFormatting } from '../types'
+import { formatSiwsMessage } from './format-siws-message'
+
+/**
+ * Signs a SIWS message using a Solana keypair signer
+ * @param siwsMessage - The formatted SIWS message to sign
+ * @param signer - The Solana KeyPairSigner from setupWallets
+ * @returns Base58-encoded signature
+ */
+export async function signSiwsMessage(siwsMessage: SiwsMessageForFormatting, signer: KeyPairSigner): Promise<string> {
+    try {
+        const message = createSignableMessage(new TextEncoder().encode(formatSiwsMessage(siwsMessage)))
+        const signedMessage = await signer.signMessages([message])
+        return ethers.utils.base58.encode(signedMessage[0][signer.address])
+    } catch (error) {
+        throw new Error(`Failed to sign SIWS message: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    }
+}
+```
+
+This utilizes a helper function, `formatSiwsMessage`, that makes sure our SIWS message object is properly formatted as defined in Phantom's SIWS message specification.
+
+##### Formatting the SIWS Message
+
+Create the file `format-siws-message.ts` in our `lit` helpers directory, and export the function `formatSiwsMessage`:
+
+```ts
+import { SiwsMessageForFormatting } from '../types'
+
+/**
+ * Formats Siws message according to the ABNF specification:
+ * https://github.com/phantom/sign-in-with-solana/blob/main/siws.md#abnf-message-format
+ *
+ * @param siws - Siws message with required domain and address fields
+ * @returns Formatted message string according to Siws ABNF specification
+ */
+export function formatSiwsMessage(siws: SiwsMessageForFormatting): string {
+    if (!siws.domain || !siws.address) {
+        throw new Error('Domain and address are required for Siws message construction')
+    }
+
+    // Start with the mandatory domain and address line
+    let message = `${siws.domain} wants you to sign in with your Solana account:\n${siws.address}`
+
+    // Add statement if provided (with double newline separator)
+    if (siws.statement) {
+        message += `\n\n${siws.statement}`
+    }
+
+    // Collect advanced fields in the correct order as per ABNF spec
+    const fields: string[] = []
+
+    if (siws.uri) {
+        fields.push(`URI: ${siws.uri}`)
+    }
+    if (siws.version) {
+        fields.push(`Version: ${siws.version}`)
+    }
+    if (siws.chainId) {
+        fields.push(`Chain ID: ${siws.chainId}`)
+    }
+    if (siws.nonce) {
+        fields.push(`Nonce: ${siws.nonce}`)
+    }
+    if (siws.issuedAt) {
+        fields.push(`Issued At: ${siws.issuedAt}`)
+    }
+    if (siws.expirationTime) {
+        fields.push(`Expiration Time: ${siws.expirationTime}`)
+    }
+    if (siws.notBefore) {
+        fields.push(`Not Before: ${siws.notBefore}`)
+    }
+    if (siws.requestId) {
+        fields.push(`Request ID: ${siws.requestId}`)
+    }
+    if (siws.resources && siws.resources.length > 0) {
+        fields.push(`Resources:`)
+        for (const resource of siws.resources) {
+            fields.push(`- ${resource}`)
+        }
+    }
+
+    // Add advanced fields if any exist (with double newline separator)
+    if (fields.length > 0) {
+        message += `\n\n${fields.join('\n')}`
+    }
+
+    return message
+}
+```
+
+##### Making the Decryption Request
+
+Lastly, back in the `verifyAttestation` function, we'll use the `decryptAttestationData` helper function to make the decryption request to the Lit network.
+
+Create the file `decrypt-attestation-data.ts` in our `lit` helpers directory, and export the function `decryptAttestationData`:
+
+```ts
+import { LitNodeClient } from '@lit-protocol/lit-node-client'
+import { generateAuthSig, createSiweMessage, LitAccessControlConditionResource, LitActionResource } from '@lit-protocol/auth-helpers'
+import { LIT_ABILITY } from '@lit-protocol/constants'
+import { ethers } from 'ethers'
+
+import { LitDecryptionResponse, SiwsMessageForFormatting } from '../types'
+import { litActionCode as litActionCodeDecrypt } from '../litActionDecrypt'
+
+export const decryptAttestationData = async ({
+    litNodeClient,
+    litPayerEthersWallet,
+    ciphertext,
+    dataToEncryptHash,
+    siwsMessage,
+    siwsMessageSignature,
+}: {
+    litNodeClient: LitNodeClient
+    litPayerEthersWallet: ethers.Wallet
+    ciphertext: string
+    dataToEncryptHash: string
+    siwsMessage: SiwsMessageForFormatting
+    siwsMessageSignature: string
+}) => {
+    try {
+        const response = await litNodeClient.executeJs({
+            code: litActionCodeDecrypt,
+            sessionSigs: await litNodeClient.getSessionSigs({
+                chain: 'ethereum',
+                expiration: new Date(Date.now() + 1000 * 60 * 10).toISOString(), // 10 minutes
+                resourceAbilityRequests: [
+                    {
+                        resource: new LitActionResource('*'),
+                        ability: LIT_ABILITY.LitActionExecution,
+                    },
+                    {
+                        resource: new LitAccessControlConditionResource('*'),
+                        ability: LIT_ABILITY.AccessControlConditionDecryption,
+                    },
+                ],
+                authNeededCallback: async ({ uri, expiration, resourceAbilityRequests }) => {
+                    const toSign = await createSiweMessage({
+                        uri,
+                        expiration,
+                        resources: resourceAbilityRequests,
+                        walletAddress: await litPayerEthersWallet.getAddress(),
+                        nonce: await litNodeClient.getLatestBlockhash(),
+                        litNodeClient,
+                    })
+
+                    return await generateAuthSig({
+                        signer: litPayerEthersWallet,
+                        toSign,
+                    })
+                },
+            }),
+            jsParams: {
+                siwsMessage: JSON.stringify(siwsMessage),
+                siwsMessageSignature,
+                ciphertext,
+                dataToEncryptHash,
+            },
+        })
+
+        const responseJSON = JSON.parse(response.response as string) as LitDecryptionResponse
+
+        if (!responseJSON.hasOwnProperty('success')) {
+            throw new Error(`Unexpected return value from Lit decryption request: ${response.response}`)
+        }
+
+        if (responseJSON.success === false) {
+            throw new Error(`Failed to decrypt attestation data: ${response.response}`)
+        }
+
+        return responseJSON.decryptedData
+    } catch (error) {
+        throw new Error(`An unexpected error occurred while decrypting the attestation data: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    }
+}
+```
+
+This functino is the main integration point for the Lit SDK, and it's responsible for setting up and executing the request to the Lit network to execute our custom Lit Action that authorizes decryption of the attestation data.
+
+For the input parameters for this function, we'll cover `litNodeClient` and `litPayerEthersWallet` in more detail later in this guide, and the remaining are as follows:
+
+- `ciphertext`: This is the encrypted attestation data that we'll be decrypting, and was obtained from the on-chain attestation data.
+- `dataToEncryptHash`: This is the hash of the data that was encrypted along with our Access Control Conditions, and was also obtained from the on-chain attestation data.
+- `siwsMessage`: This is the SIWS message that we [created previously](#creating-the-siws-message) and is used in the authorization process that validates the person making the decryption request is permitted to decrypt the attestation data.
+- `siwsMessageSignature`: This is the signature of the SIWS message that was [previously signed](#signing-the-siws-message) with one of the Credential's Authorized Signer keypairs.
+
+The `litNodeClient.executeJs` function is used to execute our custom Lit Action and takes several parameters:
+
+###### `code`
+
+```ts
+code: litActionCodeDecrypt,
+```
+
+This is the code for our custom Lit Action that will be executed on the Lit network. The code can be uploaded to IPFS and referenced here using it's IPFS CID, or the code can be provided as a string as we're doing in this guide.
+
+We setup and dive into the Lit Action code in the [Decryption Lit Action](#the-decryption-lit-action) section.
+
+###### `sessionSigs`
+
+```ts
+sessionSigs: await litNodeClient.getSessionSigs({
+    chain: "ethereum",
+    expiration: new Date(Date.now() + 1000 * 60 * 10).toISOString(), // 10 minutes
+    resourceAbilityRequests: [
+        {
+            resource: new LitActionResource("*"),
+            ability: LIT_ABILITY.LitActionExecution,
+        },
+        {
+            resource: new LitAccessControlConditionResource("*"),
+            ability: LIT_ABILITY.AccessControlConditionDecryption,
+        },
+    ],
+    authNeededCallback: async ({
+        uri,
+        expiration,
+        resourceAbilityRequests,
+    }) => {
+        const toSign = await createSiweMessage({
+            uri,
+            expiration,
+            resources: resourceAbilityRequests,
+            walletAddress: await litPayerEthersWallet.getAddress(),
+            nonce: await litNodeClient.getLatestBlockhash(),
+            litNodeClient,
+        });
+
+        return await generateAuthSig({
+            signer: litPayerEthersWallet,
+            toSign,
+        });
+    },
+}),
+```
+
+Similar to paying for gas when using a blockchain, payment is required when making requests to the Lit network that require execution by the Lit nodes e.g. decrypting data. Session Signatures are how your identity is proven to the Lit network so that payment for your request can be processed. Additionally, a Session can be restricited to only permit specific tasks such as executing Lit Actions and decrypting data, as done in this guide.
+
+Session Signatures are created by specifying what `resourceAbilityRequests` are permitted to be executed using the Session, and an authentication function given to `authNeededCallback` to prove your identity. In this guide we're signing a Sign-in-with-Ethereum message using an Ethereum wallet which we generate randomly everytime the script is run.
+
+For this guide, the identity of the person paying for the decryption request to the Lit network is irrelevant, as we're using the Lit Datil-dev network which doesn't actually charge for usage of the network, however we're still required to authenticate with the Lit network via a Session.
+
+If you'd like to transition this guide to use the Lit Datil-test or mainnet, you'll need to learn about [paying for usage of the Lit network](https://developer.litprotocol.com/paying-for-lit/overview).
+
+You can also learn more about how Session Signatures work, how to generate and customize them [here](https://developer.litprotocol.com/sdk/authentication/session-sigs/intro).
+
+###### `jsParams`
+
+```ts
+jsParams: {
+  siwsMessage: JSON.stringify(siwsMessage),
+  siwsMessageSignature,
+  ciphertext,
+  dataToEncryptHash,
+},
+```
+
+The `jsParams` is an object or parameters that will be injected into the Lit Action runtime as global variables. So the keys of this object will be the variable names, and the object values will be the values of the parameters as defined here.
+
+Our custom Lit Action requires the raw SIWS message, the signature of the SIWS message, and the Lit encryption metadata in order to perform the authorization checks and decrypt the attestation data.
+
+##### The Decryption Lit Action
+
+Create the file `litActionDecrypt.ts` outside of the `lit` helpers directory (put the file in the same directory as the `attestation-demo.ts` file), and copy and paste the following code:
+
+```ts
+// @ts-nocheck
+
+const _litActionCode = async () => {
+    // Hardcoded values for this specific attestation service instance
+    const AUTHORIZED_RPC_URL = 'https://api.devnet.solana.com'
+    const AUTHORIZED_PROGRAM_ID = '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG'
+    const AUTHORIZED_CREDENTIAL_PDA = '4MZk467hXkFjzWeog1SizZutKqKVTkbwvVKswap2QKeW'
+
+    async function fetchAccountData(rpcUrl, address) {
+        try {
+            const response = await fetch(rpcUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'getAccountInfo',
+                    params: [address, { encoding: 'base64', commitment: 'confirmed' }],
+                }),
+            })
+
+            const data = await response.json()
+            if (data.error) {
+                throw new Error(`RPC error: ${data.error.message}`)
+            }
+
+            if (!data.result || !data.result.value) {
+                throw new Error('Account not found')
+            }
+
+            const accountInfo = data.result.value
+            return {
+                data: ethers.utils.base64.decode(accountInfo.data[0]),
+                owner: accountInfo.owner,
+            }
+        } catch (error) {
+            console.error('Error fetching account data:', error)
+            throw error
+        }
+    }
+
+    function parseCredentialAccount(data) {
+        let offset = 0
+
+        // Skip discriminator (1 byte)
+        offset += 1
+
+        // Read authority (32 bytes)
+        const authority = ethers.utils.base58.encode(data.slice(offset, offset + 32))
+        offset += 32
+
+        // Read name length (4 bytes, little-endian)
+        const nameLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
+        offset += 4
+
+        // Skip name bytes
+        offset += nameLength
+
+        // Read authorized signers length (4 bytes, little-endian)
+        const signersLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
+        offset += 4
+
+        // Read authorized signers
+        const authorizedSigners = []
+        for (let i = 0; i < signersLength; i++) {
+            const signer = ethers.utils.base58.encode(data.slice(offset, offset + 32))
+            authorizedSigners.push(signer)
+            offset += 32
+        }
+
+        return { authority, authorizedSigners }
+    }
+
+    function getSiwsMessage(siwsInput) {
+        console.log('Attempting to parse SIWS message: ', siwsInput)
+
+        if (!siwsInput.domain || !siwsInput.address) {
+            throw new Error('Domain and address are required for Siws message construction')
+        }
+
+        // Start with the mandatory domain and address line
+        let message = `${siwsInput.domain} wants you to sign in with your Solana account:\n${siwsInput.address}`
+
+        // Add statement if provided (with double newline separator)
+        if (siwsInput.statement) {
+            message += `\n\n${siwsInput.statement}`
+        }
+
+        // Collect advanced fields in the correct order as per ABNF spec
+        const fields = []
+
+        if (siwsInput.uri) {
+            fields.push(`URI: ${siwsInput.uri}`)
+        }
+        if (siwsInput.version) {
+            fields.push(`Version: ${siwsInput.version}`)
+        }
+        if (siwsInput.chainId) {
+            fields.push(`Chain ID: ${siwsInput.chainId}`)
+        }
+        if (siwsInput.nonce) {
+            fields.push(`Nonce: ${siwsInput.nonce}`)
+        }
+        if (siwsInput.issuedAt) {
+            fields.push(`Issued At: ${siwsInput.issuedAt}`)
+        }
+        if (siwsInput.expirationTime) {
+            fields.push(`Expiration Time: ${siwsInput.expirationTime}`)
+        }
+        if (siwsInput.notBefore) {
+            fields.push(`Not Before: ${siwsInput.notBefore}`)
+        }
+        if (siwsInput.requestId) {
+            fields.push(`Request ID: ${siwsInput.requestId}`)
+        }
+        if (siwsInput.resources && siwsInput.resources.length > 0) {
+            fields.push(`Resources:`)
+            for (const resource of siwsInput.resources) {
+                fields.push(`- ${resource}`)
+            }
+        }
+
+        // Add advanced fields if any exist (with double newline separator)
+        if (fields.length > 0) {
+            message += `\n\n${fields.join('\n')}`
+        }
+
+        return message
+    }
+
+    function validateSiwsMessage(siwsInput) {
+        const now = new Date()
+
+        // Check if message has expired (expirationTime is in the past)
+        if (siwsInput.expirationTime) {
+            const expirationTime = new Date(siwsInput.expirationTime)
+            if (now > expirationTime) {
+                return {
+                    valid: false,
+                    error: `SIWS message has expired. Current time: ${now.toISOString()}, Expiration: ${siwsInput.expirationTime}`,
+                }
+            }
+        }
+
+        // Check if message is not yet valid (notBefore is in the future)
+        if (siwsInput.notBefore) {
+            const notBefore = new Date(siwsInput.notBefore)
+            if (now < notBefore) {
+                return {
+                    valid: false,
+                    error: `SIWS message is not yet valid. Current time: ${now.toISOString()}, Not Before: ${siwsInput.notBefore}`,
+                }
+            }
+        }
+
+        return { valid: true }
+    }
+
+    async function verifySiwsSignature(siwsMessage, signerAddress, siwsMessageSignature) {
+        try {
+            const publicKey = await crypto.subtle.importKey(
+                'raw',
+                ethers.utils.base58.decode(signerAddress),
+                {
+                    name: 'Ed25519',
+                    namedCurve: 'Ed25519',
+                },
+                false,
+                ['verify']
+            )
+
+            const isValid = await crypto.subtle.verify(
+                'Ed25519',
+                publicKey,
+                ethers.utils.base58.decode(siwsMessageSignature),
+                new TextEncoder().encode(siwsMessage)
+            )
+
+            return isValid
+        } catch (error) {
+            console.error('Error in verifySiwsSignature:', error)
+            throw error
+        }
+    }
+
+    const siwsMessageJson = JSON.parse(siwsMessage)
+    const siwsMessageString = getSiwsMessage(siwsMessageJson)
+
+    try {
+        const siwsMessageValid = validateSiwsMessage(siwsMessageJson)
+        if (!siwsMessageValid.valid) {
+            console.log('SIWS message validation failed:', siwsMessageValid.error)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'SIWS message validation failed.',
+                    error: siwsMessageValid.error,
+                }),
+            })
+        }
+    } catch (error) {
+        console.error('Error in validateSiwsMessage:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error in validateSiwsMessage.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    try {
+        const siwsSignatureValid = await verifySiwsSignature(siwsMessageString, siwsMessageJson.address, siwsMessageSignature)
+
+        if (!siwsSignatureValid) {
+            console.log('Signature is invalid.')
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Signature is invalid.',
+                }),
+            })
+        }
+
+        console.log('Signature is valid.')
+    } catch (error) {
+        console.error('Error verifying signature:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error verifying signature.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // Fetch and verify authorized signers from the hardcoded credential
+    try {
+        const accountInfo = await fetchAccountData(AUTHORIZED_RPC_URL, AUTHORIZED_CREDENTIAL_PDA)
+
+        // Verify the credential account is owned by the correct program
+        if (accountInfo.owner !== AUTHORIZED_PROGRAM_ID) {
+            console.log(`Credential PDA owner mismatch. Expected: ${AUTHORIZED_PROGRAM_ID}, Got: ${accountInfo.owner}`)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Credential PDA is not owned by the authorized program',
+                    expectedOwner: AUTHORIZED_PROGRAM_ID,
+                    actualOwner: accountInfo.owner,
+                }),
+            })
+        }
+
+        const credential = parseCredentialAccount(accountInfo.data)
+
+        // Check if the signer is authorized
+        const signerAddress = siwsMessageJson.address
+        if (!credential.authorizedSigners.includes(signerAddress)) {
+            console.log(`Signer ${signerAddress} is not in authorized signers list`)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Signer is not authorized to decrypt',
+                    authorizedSigners: credential.authorizedSigners,
+                    requestingSigner: signerAddress,
+                }),
+            })
+        }
+
+        console.log(`Signer ${signerAddress} is authorized to decrypt`)
+    } catch (error) {
+        console.error('Error checking authorized signers:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error checking authorized signers',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    try {
+        const decryptedData = await Lit.Actions.decryptAndCombine({
+            accessControlConditions: [
+                {
+                    method: '',
+                    params: [':currentActionIpfsId'],
+                    pdaParams: [],
+                    pdaInterface: { offset: 0, fields: {} },
+                    pdaKey: '',
+                    chain: 'solana',
+                    returnValueTest: {
+                        key: '',
+                        comparator: '=',
+                        value: LitAuth.actionIpfsIds[0],
+                    },
+                },
+            ],
+            ciphertext,
+            dataToEncryptHash,
+            authSig: {
+                sig: ethers.utils.hexlify(ethers.utils.base58.decode(siwsMessageSignature)).slice(2),
+                derivedVia: 'solana.signMessage',
+                signedMessage: siwsMessageString,
+                address: siwsMessageJson.address,
+            },
+            chain: 'solana',
+        })
+        return LitActions.setResponse({ response: JSON.stringify({ success: true, decryptedData }) })
+    } catch (error) {
+        console.error('Error decrypting data:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error decrypting data.',
+                error: error.toString(),
+            }),
+        })
+    }
+}
+
+export const litActionCode = `(${_litActionCode.toString()})()`
+```

--- a/docs/pages/guides/ts/lit-encrypted-attestations/getting-started.mdx
+++ b/docs/pages/guides/ts/lit-encrypted-attestations/getting-started.mdx
@@ -573,41 +573,40 @@ As covered in the [Access Control Conditions (ACCs)](#access-control-conditions-
 :::details[Click here to view the complete `encrypt-attestation-data.ts` file.]
 
 ```ts
-import { LitNodeClient } from '@lit-protocol/lit-node-client'
-import ipfsOnlyHash from 'typestub-ipfs-only-hash'
+import { SiwsMessageForFormatting, SiwsMessageInput } from '../types'
 
-import { AttestationEncryptionMetadata } from '../types'
-import { litActionCode as litActionCodeDecrypt } from '../litActionDecrypt'
+/**
+ * Creates a complete Siws message by filling in missing properties with sensible defaults
+ * @param siws - Siws message object with required address field
+ * @returns Complete Siws message with all fields populated
+ */
+export function createSiwsMessage(siws: SiwsMessageInput): SiwsMessageForFormatting {
+    const now = new Date()
+    const expirationTime = new Date(now.getTime() + 10 * 60 * 1000) // 10 minutes
 
-export const encryptAttestationData = async ({
-    litNodeClient,
-    attestationData,
-}: {
-    litNodeClient: LitNodeClient
-    attestationData: Uint8Array
-}): Promise<AttestationEncryptionMetadata> => {
-    const { ciphertext, dataToEncryptHash } = await litNodeClient.encrypt({
-        dataToEncrypt: attestationData,
-        solRpcConditions: [
-            {
-                method: '',
-                params: [':currentActionIpfsId'],
-                pdaParams: [],
-                pdaInterface: { offset: 0, fields: {} },
-                pdaKey: '',
-                chain: 'solana',
-                returnValueTest: {
-                    key: '',
-                    comparator: '=',
-                    value: await ipfsOnlyHash.of(litActionCodeDecrypt),
-                },
-            },
-        ],
-        // @ts-ignore
-        chain: 'solana',
-    })
+    // Generate a cryptographically secure nonce if not provided
+    // Uses crypto.randomUUID() and ensures alphanumeric output
+    let generatedNonce = siws.nonce
+    if (!generatedNonce) {
+        // Generate UUID and remove hyphens to get alphanumeric string
+        generatedNonce = crypto.randomUUID().replace(/-/g, '')
+    }
 
-    return { ciphertext, dataToEncryptHash }
+    // Merge siws with defaults, siws values take precedence
+    return {
+        domain: siws.domain || 'localhost',
+        address: siws.address,
+        statement: siws.statement || 'Sign this message to authenticate with Lit Protocol',
+        uri: siws.uri || 'http://localhost',
+        version: siws.version || '1',
+        chainId: siws.chainId || 'devnet', // Must be string as per Siws spec: mainnet, testnet, devnet, localnet, etc.
+        nonce: generatedNonce,
+        issuedAt: siws.issuedAt || now.toISOString(),
+        expirationTime: siws.expirationTime || expirationTime.toISOString(),
+        notBefore: siws.notBefore,
+        requestId: siws.requestId,
+        resources: siws.resources || [],
+    }
 }
 ```
 
@@ -810,35 +809,73 @@ const _litActionCode = async () => {
     }
 
     function parseCredentialAccount(data) {
-        let offset = 0
-
-        // Skip discriminator (1 byte)
-        offset += 1
-
-        // Read authority (32 bytes)
-        const authority = ethers.utils.base58.encode(data.slice(offset, offset + 32))
-        offset += 32
-
-        // Read name length (4 bytes, little-endian)
-        const nameLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
-        offset += 4
-
-        // Skip name bytes
-        offset += nameLength
-
-        // Read authorized signers length (4 bytes, little-endian)
-        const signersLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
-        offset += 4
-
-        // Read authorized signers
-        const authorizedSigners = []
-        for (let i = 0; i < signersLength; i++) {
-            const signer = ethers.utils.base58.encode(data.slice(offset, offset + 32))
-            authorizedSigners.push(signer)
-            offset += 32
+        if (!(data instanceof Uint8Array)) {
+            throw new Error('Invalid credential account data: expected Uint8Array')
         }
 
-        return { authority, authorizedSigners }
+        // Minimum: discriminator(1) + authority(32) + nameLen(4) + signersLen(4) = 41 bytes
+        if (data.length < 41) {
+            throw new Error(`Invalid credential account data: insufficient length ${data.length} (min 41)`)
+        }
+
+        const view = new DataView(data.buffer, data.byteOffset, data.byteLength)
+        let offset = 0
+
+        // Discriminator (1 byte) - SAS Credential accounts have discriminator = 0
+        const discriminator = data[offset]
+        if (discriminator !== 0) {
+            throw new Error(`Invalid credential discriminator: expected 0, got ${discriminator}`)
+        }
+        offset += 1
+
+        // Skip authority (32 bytes) - not needed for this use case
+        if (offset + 32 > data.length) {
+            throw new Error('Invalid credential account: authority truncated')
+        }
+        offset += 32
+
+        // Name length (u32 le)
+        if (offset + 4 > data.length) {
+            throw new Error('Invalid credential account: name length truncated')
+        }
+        const nameLength = view.getUint32(offset, true)
+        offset += 4
+
+        // Skip name bytes - not needed for this use case
+        if (offset + nameLength > data.length) {
+            throw new Error('Invalid credential account: name truncated')
+        }
+        offset += nameLength
+
+        // Authorized signers length (u32 le)
+        if (offset + 4 > data.length) {
+            throw new Error('Invalid credential account: signers length truncated')
+        }
+        const signersLength = view.getUint32(offset, true)
+        offset += 4
+
+        // Validate we have exactly signersLength * 32 bytes for signers
+        const remaining = data.length - offset
+        const needed = signersLength * 32
+        if (needed > remaining) {
+            throw new Error(`Invalid credential account: insufficient bytes for ${signersLength} signer(s)`)
+        }
+
+        // Read authorized signers using subarray for zero-copy
+        const authorizedSigners = new Array(signersLength)
+        for (let i = 0; i < signersLength; i++) {
+            const start = offset + i * 32
+            const signer = ethers.utils.base58.encode(data.subarray(start, start + 32))
+            authorizedSigners[i] = signer
+        }
+        offset += needed
+
+        // Ensure no trailing bytes
+        if (offset !== data.length) {
+            throw new Error(`Invalid credential account: unexpected trailing bytes (${data.length - offset} bytes)`)
+        }
+
+        return { authorizedSigners }
     }
 
     function getSiwsMessage(siwsInput) {

--- a/docs/pages/guides/ts/lit-encrypted-attestations/getting-started.mdx
+++ b/docs/pages/guides/ts/lit-encrypted-attestations/getting-started.mdx
@@ -472,8 +472,7 @@ export const decryptAttestationData = async ({
 
 :::
 
-{/* TODO */}
-For the input parameters for this function, we'll cover `litNodeClient` and `litPayerEthersWallet` in more detail later in this guide, and the remaining are as follows:
+For the input parameters for this function, we'll cover `litNodeClient` and `litPayerEthersWallet` in more detail in the [Setup Lit](#setup-litts) section, and the remaining are as follows:
 
 - `ciphertext`: This is the encrypted attestation data returned by the Lit SDK after encrypting it
 - `dataToEncryptHash`: This is the hash of the data that was encrypted along with our ACCs, also returned by the Lit SDK
@@ -492,9 +491,8 @@ This is the code for our custom decryption Lit Action that will be executed on t
 
 When submitting code to be execute by the Lit network as a Lit Action, it can be uploaded to IPFS and the IPFS CID can be provided in this `executeJs` request (and the Lit nodes will fetch the code from IPFS before executing it), or it can be provided directly as a code string, as we're doing in this guide.
 
-{/* TODO */}
 :::note
-We setup and dive into the Lit Action code in the [Decryption Lit Action](#the-decryption-lit-action) section.
+We setup and dive into the Lit Action code in the [Decryption Lit Action](#lit-action-decryptts) section.
 :::
 
 #### `sessionSigs`
@@ -568,8 +566,7 @@ So for your custom decryption Lit Action, the following global variables will be
 
 Within the `lit` directory, create a new file called `encrypt-attestation-data.ts` that will contain the helper function responsible for encrypting the attestation data using the Lit SDK.
 
-{/* TODO */}
-This function uses the `encrypt` on the Lit node client (which we create in the X section) to encrypt the attestation data, combining it with our ACCs to create the `ciphertext` and `dataToEncryptHash`.
+This function uses the `encrypt` on the Lit node client to encrypt the attestation data, combining it with our ACCs to create the `ciphertext` and `dataToEncryptHash`.
 
 As covered in the [Access Control Conditions (ACCs)](#access-control-conditions-accs) section, the ACCs are simply saying that this attestation data can only be decrypted by the Lit Action we've created for this guide.
 

--- a/docs/pages/guides/ts/lit-encrypted-attestations/getting-started.mdx
+++ b/docs/pages/guides/ts/lit-encrypted-attestations/getting-started.mdx
@@ -1,0 +1,1606 @@
+---
+title: Getting Started with Encrypted Attestation Data
+description: Learn how to encrypt and control access to attestation data using Lit Protocol's decentralized key management network
+date: 2025-08-12
+---
+
+# Getting Started with Encrypted Attestation Data
+
+:::info
+These encrypted attestations code examples are built on top of the [Basic](/guides/ts/how-to-create-digital-credentials) and [Tokenized](/guides/ts/tokenized-attestations) attestation code examples.
+
+Please make sure you have an understanding of and a complete implementation of the Basic and/or Tokenized attestation code examples before continuing.
+:::
+
+To effectively use Lit Protocol for encrypted attestations, it's important to understand the key components and how they work together to provide secure, programmable access control.
+
+## Core Concepts
+
+### Decryption Lit Action
+
+Lit Actions are JavaScript programs that run inside the secure hardware (TEEs) of Lit nodes across the decentralized Lit network. They are similar to smart contracts, but can interact with both on and off-chain data to perform complex authorization logic.
+
+Each Lit node independently executes the same Lit Action in isolation, and more than two-thirds of nodes must agree on the result for consensus. This enables Lit Actions to securely fetch data from external APIs (like Solana RPC endpoints) and perform advanced authorization logic in a decentralized, trustless manner.
+
+The Lit Action used in these encrypted attestation code examples performs the following checks to determine if the user making the decryption request is authorized to decrypt the attestation data, and if authorized, decrypts and returns the raw attestation data:
+
+1. **SIWS Authentication**: Before requesting decryption, the user signs a Sign-in-with-Solana (SIWS) message (following [Phantom's specification](https://github.com/phantom/sign-in-with-solana/tree/main)) which will be used to authenticate with the Lit network (i.e. prove they control a specific Solana wallet)
+2. **Credential Verification**: The user submits a request to the Lit network to execute the Lit Action, providing their signed SIWS message along with the encrypted attestation data to the Lit network to be decrypted
+3. **Lit Action Authentication**: The Lit network parses the SIWS message, reconstructs the raw message following Phantom's specification, and verifies the signature is valid, obtaining the Solana wallet address of the user making the decryption request
+4. **Authorization**: The Lit network checks if the Solana wallet address is listed as an authorized signer for the credential using a hardcoded credential PDA
+5. **Conditional Decryption**: Only if the authenticated user is an authorized signer for the credential, the Lit Action decrypts and returns the attestation data; otherwise, access is denied.
+
+### Access Control Conditions (ACCs)
+
+As covered in the [Introduction](/guides/ts/lit-encrypted-attestations/introduction), the ACCs are the rules that determine who can decrypt your data, and under what circumstances.
+
+The ACCs for the encrypted attestation code examples are relatively simple:
+
+```typescript
+import ipfsOnlyHash from 'typestub-ipfs-only-hash'
+
+// This is the custom Lit Action created for this demo,
+// we'll be diving into it's implementation later in this guide
+import { litActionCode as litActionCodeDecrypt } from '../litActionDecrypt'
+
+const accessControlConditions = [
+    {
+        method: '',
+        params: [':currentActionIpfsId'],
+        pdaParams: [],
+        pdaInterface: { offset: 0, fields: {} },
+        pdaKey: '',
+        chain: 'solana',
+        returnValueTest: {
+            key: '',
+            comparator: '=',
+            value: await ipfsOnlyHash.of(litActionCodeDecrypt),
+        },
+    },
+]
+```
+
+Let's break down what each field means:
+
+- `params: [':currentActionIpfsId']`: A special parameter that gets the [IPFS CID](https://docs.ipfs.tech/concepts/content-addressing/) of the currently executing Lit Action
+- `chain: 'solana'`: Tells Lit Protocol these ACCs utilize the Solana blockchain
+- `returnValueTest`: The authorization logic that must be satisfied for decryption to be permitted
+    - `comparator: '='`: The boolean operator used for comparison
+    - `value: await ipfsOnlyHash.of(litActionCodeDecrypt)`: The IPFS CID of our specific custom Lit Action for decryption
+
+These ACCs are essentially saying:
+
+> "Only allow decryption if the request is coming from the Lit Action we specifically designed for authorizing attestation decryption."
+
+Because our custom decryption Lit Action handles both SIWS message validation and verification of authorized signers for the credential, this ACC guarantees that only wallets explicitly authorized on the Solana credential are able to decrypt the attestation data.
+
+### Lit Encryption Metadata
+
+When Lit encrypts your attestation data, it returns two crucial pieces of metadata that are required for decryption:
+
+- `ciphertext`: This is the actual encrypted version of your sensitive attestation data.
+- `dataToEncryptHash`: A cryptographic hash of the original data and the ACCs used to encrypted the data.
+
+Later when we make the decryption request to Lit, we'll need to provide these two pieces of metadata to the Lit network in order for the Lit network to decrypt the attestation data.
+
+## Project Setup
+
+As mentioned previously, these encrypted attestations code examples are built on top of the [Basic](/guides/ts/how-to-create-digital-credentials) and [Tokenized](/guides/ts/tokenized-attestations) attestation code examples, so these guides will assume you're working within a project/directory containing those code examples.
+
+Let's start by adding the necessary dependencies to encrypt our attestation data with Lit:
+
+:::code-group
+
+```bash [npm]
+npm i \
+    @lit-protocol/auth-helpers \
+    @lit-protocol/constants \
+    @lit-protocol/lit-node-client \
+npm i --save-dev @lit-protocol/types
+```
+
+```bash [pnpm]
+pnpm i \
+    @lit-protocol/auth-helpers \
+    @lit-protocol/constants \
+    @lit-protocol/lit-node-client \
+pnpm i -D @lit-protocol/types
+```
+
+```bash [yarn]
+yarn add \
+    @lit-protocol/auth-helpers \
+    @lit-protocol/constants \
+    @lit-protocol/lit-node-client \
+yarn add -D @lit-protocol/types
+```
+
+:::
+
+Within the existing directory for the Basic or Tokenized attestation code examples, create a new directory called `lit` - this is where we'll be storing several helper functions used for the encrypted attestations code examples.
+
+```bash
+mkdir lit
+```
+
+The following are several helper functions that will be used by the encrypted attestations code examples. Each section will briefly cover the purpose of the helper function, and provide the complete code for the function that you're expected to copy and paste into your project with the correct file name.
+
+### `types.ts`
+
+Within the existing directory (outside of the `lit` directory we just created), create a new file called `types.ts` that will contain the types we'll be using for the code examples.
+
+These types include the interfaces for the SIWS message, and well as the expected response from the Lit network when we've successfully decrypted the attestation data.
+
+:::details[Click here to view the complete `types.ts` file.]
+
+```ts
+/**
+ * Sign-in With Solana (SIWS) messages (following Phantom's specification)
+ * https://github.com/phantom/sign-in-with-solana/tree/main
+ */
+export interface SiwsMessage {
+    /**
+     * Optional EIP-4361 domain requesting the sign-in.
+     * If not provided, the wallet must determine the domain to include in the message.
+     */
+    domain?: string
+    /**
+     * Optional Solana address performing the sign-in. The address is case-sensitive.
+     * If not provided, the wallet must determine the Address to include in the message.
+     */
+    address?: string
+    /**
+     * Optional EIP-4361 Statement. The statement is a human readable string and should not have new-line characters (\n).
+     * If not provided, the wallet must not include Statement in the message.
+     */
+    statement?: string
+    /**
+     * Optional EIP-4361 URI. The URL that is requesting the sign-in.
+     * If not provided, the wallet must not include URI in the message.
+     */
+    uri?: string
+    /**
+     * Optional EIP-4361 version.
+     * If not provided, the wallet must not include Version in the message.
+     */
+    version?: string
+    /**
+     * Optional EIP-4361 Chain ID.
+     * The chainId can be one of the following: mainnet, testnet, devnet, localnet, solana:mainnet, solana:testnet, solana:devnet.
+     * If not provided, the wallet must not include Chain ID in the message.
+     */
+    chainId?: string
+    /**
+     * Optional EIP-4361 Nonce.
+     * It should be an alphanumeric string containing a minimum of 8 characters.
+     * If not provided, the wallet must not include Nonce in the message.
+     */
+    nonce?: string
+    /**
+     * Optional ISO 8601 datetime string.
+     * This represents the time at which the sign-in request was issued to the wallet.
+     * Note: For Phantom, issuedAt has a threshold and it should be within +/- 10 minutes from the timestamp at which verification is taking place.
+     * If not provided, the wallet must not include Issued At in the message.
+     */
+    issuedAt?: string
+    /**
+     * Optional ISO 8601 datetime string.
+     * This represents the time at which the sign-in request should expire.
+     * If not provided, the wallet must not include Expiration Time in the message.
+     */
+    expirationTime?: string
+    /**
+     * Optional ISO 8601 datetime string.
+     * This represents the time at which the sign-in request becomes valid.
+     * If not provided, the wallet must not include Not Before in the message.
+     */
+    notBefore?: string
+    /**
+     * Optional EIP-4361 Request ID.
+     * In addition to using nonce to avoid replay attacks, dapps can also choose to include a unique signature in the requestId.
+     * Once the wallet returns the signed message, dapps can then verify this signature against the state to add an additional, strong layer of security.
+     * If not provided, the wallet must not include Request ID in the message.
+     */
+    requestId?: string
+    /**
+     * Optional EIP-4361 Resources.
+     * Usually a list of references in the form of URIs that the dapp wants the user to be aware of.
+     * These URIs should be separated by \n-, i.e., URIs in new lines starting with the character '-'.
+     * If not provided, the wallet must not include Resources in the message.
+     */
+    resources?: string[]
+}
+
+/**
+ * Type-safe SIWS message for formatting - requires mandatory fields domain and address
+ */
+export interface SiwsMessageForFormatting extends SiwsMessage {
+    domain: string // Required for message construction
+    address: string // Required for message construction
+}
+
+/**
+ * Input for createSiwsMessage - requires address, all other fields optional
+ */
+export interface SiwsMessageInput extends Partial<SiwsMessage> {
+    address: string // Address is mandatory for creation
+}
+
+export interface AttestationEncryptionMetadata {
+    ciphertext: string
+    dataToEncryptHash: string
+}
+
+export interface LitDecryptionResponse {
+    success: boolean
+    message: string
+    error?: string
+    authorizedSigners?: string[]
+    requestingSigner?: string
+    decryptedData?: string
+}
+```
+
+:::
+
+### `generate-credential-pda.ts`
+
+Outside of the `lit` directory, create a new file called `generate-credential-pda.ts` that will contain the helper script responsible for generating the credential PDA.
+
+This script will generate a new or load an existing Issuer keypair and use it to derive the Credential PDA address.
+
+Because our decryption Lit Action hardcodes the credential PDA, we need to generate it before running the encrypted attestation code examples, so that we can hardcode it into the Lit Action.
+
+Unlike the Basic and Tokenized attestation code examples, we don't generate a new Issuer keypair every time we run the example. Instead, we'll generate it once and save it to a keyfile in a `key-pairs` directory. This will allows us to reuse the same Issuer keypair between runs of the example, resulting in the same credential PDA address being used for our attestation.
+
+:::details[Click here to view the complete `generate-credential-pda.ts` file.]
+
+```ts
+import { deriveCredentialPda } from 'sas-lib'
+
+import { getIssuerKeypair } from './get-keypair'
+
+async function main() {
+    console.log('Starting credential PDA generator\n')
+
+    // Step 1: Get issuer keypair
+    console.log('1. Getting Issuer keypair...')
+    const issuer = await getIssuerKeypair()
+
+    // Step 2: Create Credential
+    console.log('\n2. Creating Credential...')
+    const [credentialPda] = await deriveCredentialPda({
+        authority: issuer.address,
+        name: 'LIT-ENCRYPTED-METADATA',
+    })
+
+    console.log(`Credential PDA: ${credentialPda}`)
+}
+
+main()
+    .then(() => console.log('\nCredential PDA generated successfully!'))
+    .catch(error => {
+        console.error('❌ Failed to generate credential PDA:', error)
+        process.exit(1)
+    })
+```
+
+:::
+
+### `get-keypair.ts`
+
+Outside of the `lit` directory, create a new file called `get-keypair.ts` that will contain the helper function responsible for loading the Issuer, Authorized Signer 1, and Authorized Signer 2 keypairs from the `key-pairs` directory.
+
+:::details[Click here to view the complete `get-keypair.ts` file.]
+
+```ts
+import { existsSync, mkdirSync } from 'fs'
+import { generateExtractableKeyPairSigner } from 'gill'
+import { loadKeypairSignerFromFile, saveKeypairSignerToFile } from 'gill/node'
+import path from 'path'
+
+async function generateKeypair(outputPath: string) {
+    const extractableSigner = await generateExtractableKeyPairSigner()
+    await saveKeypairSignerToFile(extractableSigner, outputPath)
+}
+
+async function getKeyPair(keyPairName: string) {
+    const keyPairDir = 'key-pairs'
+    const keyPairPath = path.join(keyPairDir, `${keyPairName}.keypair.json`)
+    if (!existsSync(keyPairPath)) {
+        // Ensure the directory exists before creating the file
+        if (!existsSync(keyPairDir)) {
+            mkdirSync(keyPairDir, { recursive: true })
+        }
+        console.log(`${keyPairName} keypair does not exist at path: ${keyPairPath}. Generating it...`)
+        await generateKeypair(keyPairPath)
+    }
+
+    return loadKeypairSignerFromFile(keyPairPath)
+}
+
+export async function getIssuerKeypair() {
+    const keypair = await getKeyPair('issuer')
+    console.log(`Got Issuer keypair with address: ${keypair.address}`)
+    return keypair
+}
+
+export async function getAuthorizedSigner1Keypair() {
+    const keypair = await getKeyPair('authorized-signer-1')
+    console.log(`Got Authorized Signer 1 keypair with address: ${keypair.address}`)
+    return keypair
+}
+
+export async function getAuthorizedSigner2Keypair() {
+    const keypair = await getKeyPair('authorized-signer-2')
+    console.log(`Got Authorized Signer 2 keypair with address: ${keypair.address}`)
+    return keypair
+}
+```
+
+:::
+
+### `create-siws-message.ts`
+
+Within the `lit` directory created previously, create a new file called `create-siws-message.ts` that will contain the helper function used to create a SIWS message according to Phantom's specification.
+
+This helper function simply intakes an object as defined by the `SiwsMessageInput` interface, and returns an object the complies with Phantom's SIWS message specification, filling in any required properties with defaults.
+
+:::details[Click here to view the complete `create-siws-message.ts` file.]
+
+```ts
+import { SiwsMessageForFormatting, SiwsMessageInput } from '../types'
+
+/**
+ * Creates a complete Siws message by filling in missing properties with sensible defaults
+ * @param siws - Siws message object with required address field
+ * @returns Complete Siws message with all fields populated
+ */
+export function createSiwsMessage(siws: SiwsMessageInput): SiwsMessageForFormatting {
+    const now = new Date()
+    const expirationTime = new Date(now.getTime() + 10 * 60 * 1000) // 10 minutes
+
+    // Generate a proper nonce if not provided (minimum 8 characters, alphanumeric)
+    const generatedNonce = siws.nonce || Math.random().toString(36).substring(2, 12) // 10 character alphanumeric
+
+    // Merge siws with defaults, siws values take precedence
+    return {
+        domain: siws.domain || 'localhost',
+        address: siws.address,
+        statement: siws.statement || 'Sign this message to authenticate with Lit Protocol',
+        uri: siws.uri || 'http://localhost',
+        version: siws.version || '1',
+        chainId: siws.chainId || 'devnet', // Must be string as per Siws spec: mainnet, testnet, devnet, localnet, etc.
+        nonce: generatedNonce,
+        issuedAt: siws.issuedAt || now.toISOString(),
+        expirationTime: siws.expirationTime || expirationTime.toISOString(),
+        notBefore: siws.notBefore,
+        requestId: siws.requestId,
+        resources: siws.resources || [],
+    }
+}
+```
+
+:::
+
+### `decrypt-attestation-data.ts`
+
+Within the `lit` directory, create a new file called `decrypt-attestation-data.ts` that will contain the helper function responsible for setting up and executing the request to the Lit network to execute our custom Lit Action that authorizes decryption of the attestation data.
+
+:::details[Click here to view the complete `decrypt-attestation-data.ts` file.]
+
+```ts
+import { LitNodeClient } from '@lit-protocol/lit-node-client'
+import { generateAuthSig, createSiweMessage, LitAccessControlConditionResource, LitActionResource } from '@lit-protocol/auth-helpers'
+import { LIT_ABILITY } from '@lit-protocol/constants'
+import { ethers } from 'ethers'
+
+import { LitDecryptionResponse, SiwsMessageForFormatting } from '../types'
+import { litActionCode as litActionCodeDecrypt } from '../litActionDecrypt'
+
+export const decryptAttestationData = async ({
+    litNodeClient,
+    litPayerEthersWallet,
+    ciphertext,
+    dataToEncryptHash,
+    siwsMessage,
+    siwsMessageSignature,
+}: {
+    litNodeClient: LitNodeClient
+    litPayerEthersWallet: ethers.Wallet
+    ciphertext: string
+    dataToEncryptHash: string
+    siwsMessage: SiwsMessageForFormatting
+    siwsMessageSignature: string
+}) => {
+    try {
+        const response = await litNodeClient.executeJs({
+            code: litActionCodeDecrypt,
+            sessionSigs: await litNodeClient.getSessionSigs({
+                chain: 'ethereum',
+                expiration: new Date(Date.now() + 1000 * 60 * 10).toISOString(), // 10 minutes
+                resourceAbilityRequests: [
+                    {
+                        resource: new LitActionResource('*'),
+                        ability: LIT_ABILITY.LitActionExecution,
+                    },
+                    {
+                        resource: new LitAccessControlConditionResource('*'),
+                        ability: LIT_ABILITY.AccessControlConditionDecryption,
+                    },
+                ],
+                authNeededCallback: async ({ uri, expiration, resourceAbilityRequests }) => {
+                    const toSign = await createSiweMessage({
+                        uri,
+                        expiration,
+                        resources: resourceAbilityRequests,
+                        walletAddress: await litPayerEthersWallet.getAddress(),
+                        nonce: await litNodeClient.getLatestBlockhash(),
+                        litNodeClient,
+                    })
+
+                    return await generateAuthSig({
+                        signer: litPayerEthersWallet,
+                        toSign,
+                    })
+                },
+            }),
+            jsParams: {
+                siwsMessage: JSON.stringify(siwsMessage),
+                siwsMessageSignature,
+                ciphertext,
+                dataToEncryptHash,
+            },
+        })
+
+        const responseJSON = JSON.parse(response.response as string) as LitDecryptionResponse
+
+        if (!responseJSON.hasOwnProperty('success')) {
+            throw new Error(`Unexpected return value from Lit decryption request: ${response.response}`)
+        }
+
+        if (responseJSON.success === false) {
+            throw new Error(`Failed to decrypt attestation data: ${response.response}`)
+        }
+
+        return responseJSON.decryptedData
+    } catch (error) {
+        throw new Error(`An unexpected error occurred while decrypting the attestation data: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    }
+}
+```
+
+:::
+
+{/* TODO */}
+For the input parameters for this function, we'll cover `litNodeClient` and `litPayerEthersWallet` in more detail later in this guide, and the remaining are as follows:
+
+- `ciphertext`: This is the encrypted attestation data returned by the Lit SDK after encrypting it
+- `dataToEncryptHash`: This is the hash of the data that was encrypted along with our ACCs, also returned by the Lit SDK
+- `siwsMessage`: This is the SIWS message that will be created by the [`createSiwsMessage`](#create-siws-messagets) helper function, and is what's submitted to the decryption Lit Action to prove the identity of the person making the decryption request
+- `siwsMessageSignature`: This is the signature of the SIWS message that should be made with one of the Credential's Authorized Signer keypairs in order for decryption to be authorized
+
+The `litNodeClient.executeJs` function is used to execute our custom Lit Action and takes several parameters:
+
+#### `code`
+
+```ts
+code: litActionCodeDecrypt,
+```
+
+This is the code for our custom decryption Lit Action that will be executed on the Lit network.
+
+When submitting code to be execute by the Lit network as a Lit Action, it can be uploaded to IPFS and the IPFS CID can be provided in this `executeJs` request (and the Lit nodes will fetch the code from IPFS before executing it), or it can be provided directly as a code string, as we're doing in this guide.
+
+{/* TODO */}
+:::note
+We setup and dive into the Lit Action code in the [Decryption Lit Action](#the-decryption-lit-action) section.
+:::
+
+#### `sessionSigs`
+
+Similar to paying for gas when using a blockchain, payment is required when making requests to the Lit network that require execution by the Lit nodes e.g. decrypting data.
+
+Session Signatures are how your identity is proven to the Lit network so that payment for your request can be processed. Additionally, a Session can be restricted to only permit specific tasks such as executing Lit Actions and decrypting data, as done in this guide, by specifying what `resourceAbilityRequests` are permitted to be executed using the Session.
+
+The `authNeededCallback` function is used to prove your identity to the Lit network. In this guide we're signing a Sign-in-with-Ethereum message using an Ethereum wallet which we generate randomly every time the script is run.
+
+For this guide, the identity of the person paying for the decryption request to the Lit network is irrelevant, as we're using the Lit test network: `Datil-dev` which doesn't actually charge for usage of the network, however we're still required to authenticate with the Lit network via a Session.
+
+:::note
+If you'd like to transition this guide to use the Lit `Datil-test` or the mainnet: `Datil`, you'll need to learn about [paying for usage of the Lit network](https://developer.litprotocol.com/paying-for-lit/overview).
+
+You can also learn more about how Session Signatures work, and how to customize them [here](https://developer.litprotocol.com/sdk/authentication/session-sigs/intro).
+:::
+
+```ts
+sessionSigs: await litNodeClient.getSessionSigs({
+    chain: "ethereum",
+    expiration: new Date(Date.now() + 1000 * 60 * 10).toISOString(), // 10 minutes
+    resourceAbilityRequests: [
+        {
+            resource: new LitActionResource("*"),
+            ability: LIT_ABILITY.LitActionExecution,
+        },
+        {
+            resource: new LitAccessControlConditionResource("*"),
+            ability: LIT_ABILITY.AccessControlConditionDecryption,
+        },
+    ],
+    authNeededCallback: async ({
+        uri,
+        expiration,
+        resourceAbilityRequests,
+    }) => {
+        const toSign = await createSiweMessage({
+            uri,
+            expiration,
+            resources: resourceAbilityRequests,
+            walletAddress: await litPayerEthersWallet.getAddress(),
+            nonce: await litNodeClient.getLatestBlockhash(),
+            litNodeClient,
+        });
+
+        return await generateAuthSig({
+            signer: litPayerEthersWallet,
+            toSign,
+        });
+    },
+}),
+```
+
+#### `jsParams`
+
+```ts
+jsParams: {
+  siwsMessage: JSON.stringify(siwsMessage),
+  siwsMessageSignature,
+  ciphertext,
+  dataToEncryptHash,
+},
+```
+
+The `jsParams` is an object that will be injected into the Lit Action runtime as global variables. The keys of this object will be the variable names, and the object values will be the values of the parameters.
+
+So for your custom decryption Lit Action, the following global variables will be available: `siwsMessage`, `siwsMessageSignature`, `ciphertext`, and `dataToEncryptHash`, and will be used to perform the authorization checks and decrypt the attestation data.
+
+### `encrypt-attestation-data.ts`
+
+Within the `lit` directory, create a new file called `encrypt-attestation-data.ts` that will contain the helper function responsible for encrypting the attestation data using the Lit SDK.
+
+{/* TODO */}
+This function uses the `encrypt` on the Lit node client (which we create in the X section) to encrypt the attestation data, combining it with our ACCs to create the `ciphertext` and `dataToEncryptHash`.
+
+As covered in the [Access Control Conditions (ACCs)](#access-control-conditions-accs) section, the ACCs are simply saying that this attestation data can only be decrypted by the Lit Action we've created for this guide.
+
+:::details[Click here to view the complete `encrypt-attestation-data.ts` file.]
+
+```ts
+import { LitNodeClient } from '@lit-protocol/lit-node-client'
+import ipfsOnlyHash from 'typestub-ipfs-only-hash'
+
+import { AttestationEncryptionMetadata } from '../types'
+import { litActionCode as litActionCodeDecrypt } from '../litActionDecrypt'
+
+export const encryptAttestationData = async ({
+    litNodeClient,
+    attestationData,
+}: {
+    litNodeClient: LitNodeClient
+    attestationData: Uint8Array
+}): Promise<AttestationEncryptionMetadata> => {
+    const { ciphertext, dataToEncryptHash } = await litNodeClient.encrypt({
+        dataToEncrypt: attestationData,
+        solRpcConditions: [
+            {
+                method: '',
+                params: [':currentActionIpfsId'],
+                pdaParams: [],
+                pdaInterface: { offset: 0, fields: {} },
+                pdaKey: '',
+                chain: 'solana',
+                returnValueTest: {
+                    key: '',
+                    comparator: '=',
+                    value: await ipfsOnlyHash.of(litActionCodeDecrypt),
+                },
+            },
+        ],
+        // @ts-ignore
+        chain: 'solana',
+    })
+
+    return { ciphertext, dataToEncryptHash }
+}
+```
+
+:::
+
+The return values of this function are the `ciphertext` and `dataToEncryptHash` strings which are used by the [`decrypt-attestation-data.ts`](#decrypt-attestation-datats) helper function to perform the decryption.
+
+### `format-siws-message.ts`
+
+Within the `lit` directory, create a new file called `format-siws-message.ts` that will contain the helper function responsible for formatting the SIWS message as a string according to Phantom's specification.
+
+The output of this function is the `siwsMessage` string that will be signed and submitted to the decryption Lit Action to prove the identity of the person making the decryption request.
+
+:::details[Click here to view the complete `format-siws-message.ts` file.]
+
+```ts
+import { SiwsMessageForFormatting } from '../types'
+
+/**
+ * Formats Siws message according to the ABNF specification:
+ * https://github.com/phantom/sign-in-with-solana/blob/main/siws.md#abnf-message-format
+ *
+ * @param siws - Siws message with required domain and address fields
+ * @returns Formatted message string according to Siws ABNF specification
+ */
+export function formatSiwsMessage(siws: SiwsMessageForFormatting): string {
+    if (!siws.domain || !siws.address) {
+        throw new Error('Domain and address are required for Siws message construction')
+    }
+
+    // Start with the mandatory domain and address line
+    let message = `${siws.domain} wants you to sign in with your Solana account:\n${siws.address}`
+
+    // Add statement if provided (with double newline separator)
+    if (siws.statement) {
+        message += `\n\n${siws.statement}`
+    }
+
+    // Collect advanced fields in the correct order as per ABNF spec
+    const fields: string[] = []
+
+    if (siws.uri) {
+        fields.push(`URI: ${siws.uri}`)
+    }
+    if (siws.version) {
+        fields.push(`Version: ${siws.version}`)
+    }
+    if (siws.chainId) {
+        fields.push(`Chain ID: ${siws.chainId}`)
+    }
+    if (siws.nonce) {
+        fields.push(`Nonce: ${siws.nonce}`)
+    }
+    if (siws.issuedAt) {
+        fields.push(`Issued At: ${siws.issuedAt}`)
+    }
+    if (siws.expirationTime) {
+        fields.push(`Expiration Time: ${siws.expirationTime}`)
+    }
+    if (siws.notBefore) {
+        fields.push(`Not Before: ${siws.notBefore}`)
+    }
+    if (siws.requestId) {
+        fields.push(`Request ID: ${siws.requestId}`)
+    }
+    if (siws.resources && siws.resources.length > 0) {
+        fields.push(`Resources:`)
+        for (const resource of siws.resources) {
+            fields.push(`- ${resource}`)
+        }
+    }
+
+    // Add advanced fields if any exist (with double newline separator)
+    if (fields.length > 0) {
+        message += `\n\n${fields.join('\n')}`
+    }
+
+    return message
+}
+```
+
+:::
+
+### `setup-lit.ts`
+
+Within the `lit` directory, create a new file called `setup-lit.ts` that will contain the helper function responsible for setting up the Lit node client and the random Ethereum wallet used as the Lit payer wallet.
+
+As mentioned in the [Session Signatures](#sessionsigs) section, the Lit payer wallet is used to pay for the decryption request to the Lit network, but because we're using the Lit test network: `Datil-dev` which doesn't actually charge for usage of the network, we can use a random Ethereum wallet as the payer wallet.
+
+:::details[Click here to view the complete `setup-lit.ts` file.]
+
+```ts
+import { LIT_NETWORK, LIT_RPC } from '@lit-protocol/constants'
+import { LitNodeClient } from '@lit-protocol/lit-node-client'
+import { LIT_NETWORKS_KEYS } from '@lit-protocol/types'
+import { ethers } from 'ethers'
+
+export async function setupLit({
+    litNetwork = LIT_NETWORK.DatilDev,
+    debug = false,
+}: {
+    litNetwork?: LIT_NETWORKS_KEYS
+    debug?: boolean
+} = {}) {
+    const litPayerEthersWallet = new ethers.Wallet(ethers.Wallet.createRandom().privateKey, new ethers.providers.JsonRpcProvider(LIT_RPC.CHRONICLE_YELLOWSTONE))
+
+    const litNodeClient = new LitNodeClient({
+        litNetwork,
+        debug,
+    })
+    await litNodeClient.connect()
+
+    return {
+        litNodeClient,
+        litPayerEthersWallet,
+    }
+}
+```
+
+:::
+
+### `sign-siws-message.ts`
+
+Within the `lit` directory, create a new file called `sign-siws-message.ts` that will contain the helper function responsible for signing the SIWS message with one of the Credential's Authorized Signer keypairs.
+
+:::details[Click here to view the complete `sign-siws-message.ts` file.]
+
+```ts
+import { ethers } from 'ethers'
+import { createSignableMessage, KeyPairSigner } from 'gill'
+
+import { SiwsMessageForFormatting } from '../types'
+import { formatSiwsMessage } from './format-siws-message'
+
+/**
+ * Signs a SIWS message using a Solana keypair signer
+ * @param siwsMessage - The formatted SIWS message to sign
+ * @param signer - The Solana KeyPairSigner from setupWallets
+ * @returns Base58-encoded signature
+ */
+export async function signSiwsMessage(siwsMessage: SiwsMessageForFormatting, signer: KeyPairSigner): Promise<string> {
+    try {
+        const message = createSignableMessage(new TextEncoder().encode(formatSiwsMessage(siwsMessage)))
+        const signedMessage = await signer.signMessages([message])
+        return ethers.utils.base58.encode(signedMessage[0][signer.address])
+    } catch (error) {
+        throw new Error(`Failed to sign SIWS message: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    }
+}
+```
+
+:::
+
+### `lit-action-decrypt.ts`
+
+Within the `lit` directory, create a new file called `lit-action-decrypt.ts` that will contain the custom Lit Action responsible for decrypting the attestation data.
+
+:::details[Click here to view the complete `lit-action-decrypt.ts` file.]
+
+```ts
+// @ts-nocheck
+
+const _litActionCode = async () => {
+    // Hardcoded values for this specific attestation service instance
+    const AUTHORIZED_RPC_URL = 'https://api.devnet.solana.com'
+    const AUTHORIZED_PROGRAM_ID = '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG'
+    const AUTHORIZED_CREDENTIAL_PDA = 'Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk'
+
+    async function fetchAccountData(rpcUrl, address) {
+        try {
+            const response = await fetch(rpcUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'getAccountInfo',
+                    params: [address, { encoding: 'base64', commitment: 'confirmed' }],
+                }),
+            })
+
+            const data = await response.json()
+            if (data.error) {
+                throw new Error(`RPC error: ${data.error.message}`)
+            }
+
+            if (!data.result || !data.result.value) {
+                throw new Error('Account not found')
+            }
+
+            const accountInfo = data.result.value
+            return {
+                data: ethers.utils.base64.decode(accountInfo.data[0]),
+                owner: accountInfo.owner,
+            }
+        } catch (error) {
+            console.error('Error fetching account data:', error)
+            throw error
+        }
+    }
+
+    function parseCredentialAccount(data) {
+        let offset = 0
+
+        // Skip discriminator (1 byte)
+        offset += 1
+
+        // Read authority (32 bytes)
+        const authority = ethers.utils.base58.encode(data.slice(offset, offset + 32))
+        offset += 32
+
+        // Read name length (4 bytes, little-endian)
+        const nameLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
+        offset += 4
+
+        // Skip name bytes
+        offset += nameLength
+
+        // Read authorized signers length (4 bytes, little-endian)
+        const signersLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
+        offset += 4
+
+        // Read authorized signers
+        const authorizedSigners = []
+        for (let i = 0; i < signersLength; i++) {
+            const signer = ethers.utils.base58.encode(data.slice(offset, offset + 32))
+            authorizedSigners.push(signer)
+            offset += 32
+        }
+
+        return { authority, authorizedSigners }
+    }
+
+    function getSiwsMessage(siwsInput) {
+        console.log('Attempting to parse SIWS message: ', siwsInput)
+
+        if (!siwsInput.domain || !siwsInput.address) {
+            throw new Error('Domain and address are required for Siws message construction')
+        }
+
+        // Start with the mandatory domain and address line
+        let message = `${siwsInput.domain} wants you to sign in with your Solana account:\n${siwsInput.address}`
+
+        // Add statement if provided (with double newline separator)
+        if (siwsInput.statement) {
+            message += `\n\n${siwsInput.statement}`
+        }
+
+        // Collect advanced fields in the correct order as per ABNF spec
+        const fields = []
+
+        if (siwsInput.uri) {
+            fields.push(`URI: ${siwsInput.uri}`)
+        }
+        if (siwsInput.version) {
+            fields.push(`Version: ${siwsInput.version}`)
+        }
+        if (siwsInput.chainId) {
+            fields.push(`Chain ID: ${siwsInput.chainId}`)
+        }
+        if (siwsInput.nonce) {
+            fields.push(`Nonce: ${siwsInput.nonce}`)
+        }
+        if (siwsInput.issuedAt) {
+            fields.push(`Issued At: ${siwsInput.issuedAt}`)
+        }
+        if (siwsInput.expirationTime) {
+            fields.push(`Expiration Time: ${siwsInput.expirationTime}`)
+        }
+        if (siwsInput.notBefore) {
+            fields.push(`Not Before: ${siwsInput.notBefore}`)
+        }
+        if (siwsInput.requestId) {
+            fields.push(`Request ID: ${siwsInput.requestId}`)
+        }
+        if (siwsInput.resources && siwsInput.resources.length > 0) {
+            fields.push(`Resources:`)
+            for (const resource of siwsInput.resources) {
+                fields.push(`- ${resource}`)
+            }
+        }
+
+        // Add advanced fields if any exist (with double newline separator)
+        if (fields.length > 0) {
+            message += `\n\n${fields.join('\n')}`
+        }
+
+        return message
+    }
+
+    function validateSiwsMessage(siwsInput) {
+        const now = new Date()
+
+        // Check if message has expired (expirationTime is in the past)
+        if (siwsInput.expirationTime) {
+            const expirationTime = new Date(siwsInput.expirationTime)
+            if (now > expirationTime) {
+                return {
+                    valid: false,
+                    error: `SIWS message has expired. Current time: ${now.toISOString()}, Expiration: ${siwsInput.expirationTime}`,
+                }
+            }
+        }
+
+        // Check if message is not yet valid (notBefore is in the future)
+        if (siwsInput.notBefore) {
+            const notBefore = new Date(siwsInput.notBefore)
+            if (now < notBefore) {
+                return {
+                    valid: false,
+                    error: `SIWS message is not yet valid. Current time: ${now.toISOString()}, Not Before: ${siwsInput.notBefore}`,
+                }
+            }
+        }
+
+        return { valid: true }
+    }
+
+    async function verifySiwsSignature(siwsMessage, signerAddress, siwsMessageSignature) {
+        try {
+            const publicKey = await crypto.subtle.importKey(
+                'raw',
+                ethers.utils.base58.decode(signerAddress),
+                {
+                    name: 'Ed25519',
+                    namedCurve: 'Ed25519',
+                },
+                false,
+                ['verify']
+            )
+
+            const isValid = await crypto.subtle.verify(
+                'Ed25519',
+                publicKey,
+                ethers.utils.base58.decode(siwsMessageSignature),
+                new TextEncoder().encode(siwsMessage)
+            )
+
+            return isValid
+        } catch (error) {
+            console.error('Error in verifySiwsSignature:', error)
+            throw error
+        }
+    }
+
+    const siwsMessageJson = JSON.parse(siwsMessage)
+    const siwsMessageString = getSiwsMessage(siwsMessageJson)
+
+    try {
+        const siwsMessageValid = validateSiwsMessage(siwsMessageJson)
+        if (!siwsMessageValid.valid) {
+            console.log('SIWS message validation failed:', siwsMessageValid.error)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'SIWS message validation failed.',
+                    error: siwsMessageValid.error,
+                }),
+            })
+        }
+    } catch (error) {
+        console.error('Error in validateSiwsMessage:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error in validateSiwsMessage.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    try {
+        const siwsSignatureValid = await verifySiwsSignature(siwsMessageString, siwsMessageJson.address, siwsMessageSignature)
+
+        if (!siwsSignatureValid) {
+            console.log('Signature is invalid.')
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Signature is invalid.',
+                }),
+            })
+        }
+
+        console.log('Signature is valid.')
+    } catch (error) {
+        console.error('Error verifying signature:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error verifying signature.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // Fetch and verify authorized signers from the hardcoded credential
+    try {
+        const accountInfo = await fetchAccountData(AUTHORIZED_RPC_URL, AUTHORIZED_CREDENTIAL_PDA)
+
+        // Verify the credential account is owned by the correct program
+        if (accountInfo.owner !== AUTHORIZED_PROGRAM_ID) {
+            console.log(`Credential PDA owner mismatch. Expected: ${AUTHORIZED_PROGRAM_ID}, Got: ${accountInfo.owner}`)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Credential PDA is not owned by the authorized program',
+                    expectedOwner: AUTHORIZED_PROGRAM_ID,
+                    actualOwner: accountInfo.owner,
+                }),
+            })
+        }
+
+        const credential = parseCredentialAccount(accountInfo.data)
+
+        // Check if the signer is authorized
+        const signerAddress = siwsMessageJson.address
+        if (!credential.authorizedSigners.includes(signerAddress)) {
+            console.log(`Signer ${signerAddress} is not in authorized signers list`)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Signer is not authorized to decrypt',
+                    authorizedSigners: credential.authorizedSigners,
+                    requestingSigner: signerAddress,
+                }),
+            })
+        }
+
+        console.log(`Signer ${signerAddress} is authorized to decrypt`)
+    } catch (error) {
+        console.error('Error checking authorized signers:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error checking authorized signers',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    try {
+        const decryptedData = await Lit.Actions.decryptAndCombine({
+            accessControlConditions: [
+                {
+                    method: '',
+                    params: [':currentActionIpfsId'],
+                    pdaParams: [],
+                    pdaInterface: { offset: 0, fields: {} },
+                    pdaKey: '',
+                    chain: 'solana',
+                    returnValueTest: {
+                        key: '',
+                        comparator: '=',
+                        value: LitAuth.actionIpfsIds[0],
+                    },
+                },
+            ],
+            ciphertext,
+            dataToEncryptHash,
+            authSig: {
+                sig: ethers.utils.hexlify(ethers.utils.base58.decode(siwsMessageSignature)).slice(2),
+                derivedVia: 'solana.signMessage',
+                signedMessage: siwsMessageString,
+                address: siwsMessageJson.address,
+            },
+            chain: 'solana',
+        })
+        return LitActions.setResponse({ response: JSON.stringify({ success: true, decryptedData }) })
+    } catch (error) {
+        console.error('Error decrypting data:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error decrypting data.',
+                error: error.toString(),
+            }),
+        })
+    }
+}
+
+export const litActionCode = `(${_litActionCode.toString()})()`
+```
+
+:::
+
+#### The Structure of the Lit Action Code
+
+For the encrypting attestation example, we provide the Lit Action code as a stringified self executing function using the following syntax:
+
+```ts
+const _litActionCode = async () => {
+    // Lit Action code...
+}
+
+export const litActionCode = `(${_litActionCode.toString()})()`
+```
+
+The `litActionCode` variable is the stringified self executing function, and what we import and provide to the Lit SDK as the [code](#code) parameter to the `litNodeClient.executeJs` call.
+
+#### Hardcoded Solana Constants
+
+```ts
+const _litActionCode = async () => {
+    // Hardcoded values for this specific attestation service instance
+    const AUTHORIZED_RPC_URL = 'https://api.devnet.solana.com'
+    const AUTHORIZED_PROGRAM_ID = '22zoJMtdu4tQc2PzL74ZUT7FrwgB1Udec8DdW4yw4BdG'
+    const AUTHORIZED_CREDENTIAL_PDA = 'Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk'
+
+    // The rest of the Lit Action code...
+}
+```
+
+- The `AUTHORIZED_RPC_URL` is the RPC URL of the Solana cluster that the attestation service is running on.
+- The `AUTHORIZED_PROGRAM_ID` is the program ID of the attestation service.
+- The `AUTHORIZED_CREDENTIAL_PDA` is the Credential PDA that was derived from the Issuer keypair.
+    - This PDA is unique to your Issuer keypair and is used to identify whether the requestor of the decryption request is authorized to decrypt the attestation data.
+    - We generated this PDA earlier in the [Running the Generate Credential PDA Script](#running-the-generate-credential-pda-script) section:
+        ```bash
+        2. Creating Credential...
+        Credential PDA: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
+        ```
+
+#### Fetching Account Data
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    async function fetchAccountData(rpcUrl, address) {
+        try {
+            const response = await fetch(rpcUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'getAccountInfo',
+                    params: [address, { encoding: 'base64', commitment: 'confirmed' }],
+                }),
+            })
+
+            const data = await response.json()
+            if (data.error) {
+                throw new Error(`RPC error: ${data.error.message}`)
+            }
+
+            if (!data.result || !data.result.value) {
+                throw new Error('Account not found')
+            }
+
+            const accountInfo = data.result.value
+            return {
+                data: ethers.utils.base64.decode(accountInfo.data[0]),
+                owner: accountInfo.owner,
+            }
+        } catch (error) {
+            console.error('Error fetching account data:', error)
+            throw error
+        }
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `fetchAccountData` function is a utility method that allows the Lit Action to query Solana's blockchain state directly from within the secure execution environment. It fetches and decodes account data from Solana using the `getAccountInfo` RPC call, handling errors, and returning both the account's data and owner. This will enable the Lit Action to check which signers are authorized to decrypt the attestation later in the code.
+
+#### Parsing the Credential Account Data
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    function parseCredentialAccount(data) {
+        let offset = 0
+
+        // Skip discriminator (1 byte)
+        offset += 1
+
+        // Read authority (32 bytes)
+        const authority = ethers.utils.base58.encode(data.slice(offset, offset + 32))
+        offset += 32
+
+        // Read name length (4 bytes, little-endian)
+        const nameLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
+        offset += 4
+
+        // Skip name bytes
+        offset += nameLength
+
+        // Read authorized signers length (4 bytes, little-endian)
+        const signersLength = new DataView(data.buffer, offset, 4).getUint32(0, true)
+        offset += 4
+
+        // Read authorized signers
+        const authorizedSigners = []
+        for (let i = 0; i < signersLength; i++) {
+            const signer = ethers.utils.base58.encode(data.slice(offset, offset + 32))
+            authorizedSigners.push(signer)
+            offset += 32
+        }
+
+        return { authority, authorizedSigners }
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `parseCredentialAccount` function deserializes the raw bytes returned from the Solana RPC into a readable credential account structure. It manually parses the binary data by reading specific byte offsets that correspond to the on-chain account layout: skipping the discriminator, extracting the authority public key, reading the name length and skipping those bytes, then finally extracting the list of authorized signers. This parsing is necessary because Solana stores account data as raw bytes, and we need to extract the authorized signers list to verify if the requesting signer has permission to decrypt the attestation data.
+
+#### Recreating the SIWS Message
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    function getSiwsMessage(siwsInput) {
+        console.log('Attempting to parse SIWS message: ', siwsInput)
+
+        if (!siwsInput.domain || !siwsInput.address) {
+            throw new Error('Domain and address are required for Siws message construction')
+        }
+
+        // Start with the mandatory domain and address line
+        let message = `${siwsInput.domain} wants you to sign in with your Solana account:\n${siwsInput.address}`
+
+        // Add statement if provided (with double newline separator)
+        if (siwsInput.statement) {
+            message += `\n\n${siwsInput.statement}`
+        }
+
+        // Collect advanced fields in the correct order as per ABNF spec
+        const fields = []
+
+        if (siwsInput.uri) {
+            fields.push(`URI: ${siwsInput.uri}`)
+        }
+        if (siwsInput.version) {
+            fields.push(`Version: ${siwsInput.version}`)
+        }
+        if (siwsInput.chainId) {
+            fields.push(`Chain ID: ${siwsInput.chainId}`)
+        }
+        if (siwsInput.nonce) {
+            fields.push(`Nonce: ${siwsInput.nonce}`)
+        }
+        if (siwsInput.issuedAt) {
+            fields.push(`Issued At: ${siwsInput.issuedAt}`)
+        }
+        if (siwsInput.expirationTime) {
+            fields.push(`Expiration Time: ${siwsInput.expirationTime}`)
+        }
+        if (siwsInput.notBefore) {
+            fields.push(`Not Before: ${siwsInput.notBefore}`)
+        }
+        if (siwsInput.requestId) {
+            fields.push(`Request ID: ${siwsInput.requestId}`)
+        }
+        if (siwsInput.resources && siwsInput.resources.length > 0) {
+            fields.push(`Resources:`)
+            for (const resource of siwsInput.resources) {
+                fields.push(`- ${resource}`)
+            }
+        }
+
+        // Add advanced fields if any exist (with double newline separator)
+        if (fields.length > 0) {
+            message += `\n\n${fields.join('\n')}`
+        }
+
+        return message
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `getSiwsMessage` function reconstructs the SIWS message string from the JSON input provided as `siwsMessage` in the [`jsParams` Lit Action parameter](#jsparams) within the secure Lit Action environment. This reconstruction is a critical security step that avoids trusting the message string passed as input (which could be manipulated), and instead rebuilds the message from its individual components according to Phantom's SIWS specification. This ensures the message structure matches what was originally signed by the user.
+
+#### Validating the SIWS Message
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    function validateSiwsMessage(siwsInput) {
+        const now = new Date()
+
+        // Check if message has expired (expirationTime is in the past)
+        if (siwsInput.expirationTime) {
+            const expirationTime = new Date(siwsInput.expirationTime)
+            if (now > expirationTime) {
+                return {
+                    valid: false,
+                    error: `SIWS message has expired. Current time: ${now.toISOString()}, Expiration: ${siwsInput.expirationTime}`,
+                }
+            }
+        }
+
+        // Check if message is not yet valid (notBefore is in the future)
+        if (siwsInput.notBefore) {
+            const notBefore = new Date(siwsInput.notBefore)
+            if (now < notBefore) {
+                return {
+                    valid: false,
+                    error: `SIWS message is not yet valid. Current time: ${now.toISOString()}, Not Before: ${siwsInput.notBefore}`,
+                }
+            }
+        }
+
+        return { valid: true }
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `validateSiwsMessage` function performs time-based validation on the SIWS message to prevent replay attacks and ensure the authentication request is fresh. It checks two optional time constraints: the `expirationTime` field to ensure the message hasn't expired, and the `notBefore` field to ensure the message isn't being used before its intended validity period.
+
+#### Verifying the SIWS Signature
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    async function verifySiwsSignature(siwsMessage, signerAddress, siwsMessageSignature) {
+        try {
+            const publicKey = await crypto.subtle.importKey(
+                'raw',
+                ethers.utils.base58.decode(signerAddress),
+                {
+                    name: 'Ed25519',
+                    namedCurve: 'Ed25519',
+                },
+                false,
+                ['verify']
+            )
+
+            const isValid = await crypto.subtle.verify(
+                'Ed25519',
+                publicKey,
+                ethers.utils.base58.decode(siwsMessageSignature),
+                new TextEncoder().encode(siwsMessage)
+            )
+
+            return isValid
+        } catch (error) {
+            console.error('Error in verifySiwsSignature:', error)
+            throw error
+        }
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `verifySiwsSignature` function performs cryptographic verification to confirm the SIWS message was actually signed by the claimed wallet address. It uses the Web Crypto API to import the public key from the Solana address (converting from Base58 format), then verifies the Ed25519 signature against the reconstructed message string. This cryptographic proof ensures that only someone with the private key corresponding to the claimed address could have created the signature, preventing impersonation attacks where malicious users might try to claim they control a wallet they don't actually own.
+
+#### Putting It All Together
+
+Now that we've covered the individual functions that make up the Lit Action code, let's put it all together to perform the SIWS message validation, and check if the message signer is authorized to decrypt the attestation data.
+
+The first steps is to parse the SIWS message into a JSON object, and reconstruct the SIWS message from the input parameters: `siwsMessage` to ensure the message is valid and not expired, or being used before its intended validity period:
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    const siwsMessageJson = JSON.parse(siwsMessage)
+    const siwsMessageString = getSiwsMessage(siwsMessageJson)
+
+    try {
+        const siwsMessageValid = validateSiwsMessage(siwsMessageJson)
+        if (!siwsMessageValid.valid) {
+            console.log('SIWS message validation failed:', siwsMessageValid.error)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'SIWS message validation failed.',
+                    error: siwsMessageValid.error,
+                }),
+            })
+        }
+    } catch (error) {
+        console.error('Error in validateSiwsMessage:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error in validateSiwsMessage.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+Next, we'll verify the SIWS signature to ensure the message was actually signed by the claimed wallet address:
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    try {
+        const siwsSignatureValid = await verifySiwsSignature(siwsMessageString, siwsMessageJson.address, siwsMessageSignature)
+
+        if (!siwsSignatureValid) {
+            console.log('Signature is invalid.')
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Signature is invalid.',
+                }),
+            })
+        }
+
+        console.log('Signature is valid.')
+    } catch (error) {
+        console.error('Error verifying signature:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error verifying signature.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+Then we perform the authorization check by fetching the hardcoded Credential account from Solana to verify decryption permissions. This involves a multi-step security validation:
+
+1. We confirm the credential account is owned by the legitimate Solana Attestation Service program (preventing attacks using fake credential accounts).
+2. We parse the account data to extract the authorized signers list.
+3. We verify that the authenticated wallet address from our SIWS message is actually included in this list of permitted decryption signers.
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    // Fetch and verify authorized signers from the hardcoded credential
+    try {
+        const accountInfo = await fetchAccountData(AUTHORIZED_RPC_URL, AUTHORIZED_CREDENTIAL_PDA)
+
+        // Verify the credential account is owned by the correct program
+        if (accountInfo.owner !== AUTHORIZED_PROGRAM_ID) {
+            console.log(`Credential PDA owner mismatch. Expected: ${AUTHORIZED_PROGRAM_ID}, Got: ${accountInfo.owner}`)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Credential PDA is not owned by the authorized program',
+                    expectedOwner: AUTHORIZED_PROGRAM_ID,
+                    actualOwner: accountInfo.owner,
+                }),
+            })
+        }
+
+        const credential = parseCredentialAccount(accountInfo.data)
+
+        // Check if the signer is authorized
+        const signerAddress = siwsMessageJson.address
+        if (!credential.authorizedSigners.includes(signerAddress)) {
+            console.log(`Signer ${signerAddress} is not in authorized signers list`)
+            return LitActions.setResponse({
+                response: JSON.stringify({
+                    success: false,
+                    message: 'Signer is not authorized to decrypt',
+                    authorizedSigners: credential.authorizedSigners,
+                    requestingSigner: signerAddress,
+                }),
+            })
+        }
+
+        console.log(`Signer ${signerAddress} is authorized to decrypt`)
+    } catch (error) {
+        console.error('Error checking authorized signers:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error checking authorized signers',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+Lastly, after validating the signer of the SIWS message is authorized to decrypt the attestation data, we can proceed to decrypt the attestation data using `Lit.Actions.decryptAndCombine`:
+
+```ts
+const _litActionCode = async () => {
+    // Previous Lit Action code...
+
+    try {
+        const decryptedData = await Lit.Actions.decryptAndCombine({
+            accessControlConditions: [
+                {
+                    method: '',
+                    params: [':currentActionIpfsId'],
+                    pdaParams: [],
+                    pdaInterface: { offset: 0, fields: {} },
+                    pdaKey: '',
+                    chain: 'solana',
+                    returnValueTest: {
+                        key: '',
+                        comparator: '=',
+                        value: LitAuth.actionIpfsIds[0],
+                    },
+                },
+            ],
+            ciphertext,
+            dataToEncryptHash,
+            authSig: {
+                sig: ethers.utils.hexlify(ethers.utils.base58.decode(siwsMessageSignature)).slice(2),
+                derivedVia: 'solana.signMessage',
+                signedMessage: siwsMessageString,
+                address: siwsMessageJson.address,
+            },
+            chain: 'solana',
+        })
+        return LitActions.setResponse({ response: JSON.stringify({ success: true, decryptedData }) })
+    } catch (error) {
+        console.error('Error decrypting data:', error)
+        return LitActions.setResponse({
+            response: JSON.stringify({
+                success: false,
+                message: 'Error decrypting data.',
+                error: error.toString(),
+            }),
+        })
+    }
+
+    // The rest of the Lit Action code...
+}
+```
+
+The `Lit.Actions.decryptAndCombine` function is part of the Lit Actions SDK and is available globally within the Lit node execution environment. When invoked, it initiates the distributed decryption process across the Lit network. Each participating Lit node checks whether the provided Access Control Conditions are satisfied, and if so, generates and shares its decryption share with the network. Once enough valid shares are collected (2/3 of the total Lit nodes), they are combined to reconstruct the decrypted data, which is then returned to the Lit Action.
+
+The parameters for `Lit.Actions.decryptAndCombine` are:
+
+- `accessControlConditions`: An array of Access Control Conditions that must be satisfied for the decryption to occur.
+- `ciphertext`: The ciphertext to decrypt that we fetched from the on-chain Attestation account.
+- `dataToEncryptHash`: The hash of the data to encrypt that we fetched from the on-chain Attestation account.
+- `authSig`: The signature of the SIWS message used by the Lit nodes to authenticate who's making the decryption request.
+- `chain`: The chain corresponding to the `authSig` parameter (in this case, `solana` because we're providing a signature using a Solana keypair).
+
+### `index.ts`
+
+In the `lit` directory, create a new file called `index.ts` that we'll use to export all of our helper functions, making it easier to import them into our encrypted attestation examples:
+
+```ts
+export * from './encrypt-attestation-data'
+export * from './create-siws-message'
+export * from './format-siws-message'
+export * from './sign-siws-message'
+export * from './setup-lit'
+export * from './decrypt-attestation-data'
+```
+
+### Final Directory Structure
+
+After creating all the above files, your directory structure should look like this:
+
+```
+├── generate-credential-pda.ts
+├── get-keypair.ts
+├── lit
+│   ├── create-siws-message.ts
+│   ├── decrypt-attestation-data.ts
+│   ├── encrypt-attestation-data.ts
+│   ├── format-siws-message.ts
+│   ├── index.ts
+│   ├── lit-action-decrypt.ts
+│   ├── setup-lit.ts
+│   └── sign-siws-message.ts
+├── attestation-demo.ts
+├── tokenized-attestation-demo.ts
+└── types.ts
+```
+
+## Next Steps
+
+Now that we have all the prerequisite Lit helpers functions, we can integrate them into the `attestation-demo.ts` and `tokenized-attestation-demo.ts` files to create our encrypted attestation examples.
+
+- [Encrypted Basic Attestation Flow](/guides/ts/lit-encrypted-attestations/basic-attestation-flow)
+- [Encrypted Tokenized Attestation](/guides/ts/lit-encrypted-attestations/tokenized-attestation)

--- a/docs/pages/guides/ts/lit-encrypted-attestations/introduction.mdx
+++ b/docs/pages/guides/ts/lit-encrypted-attestations/introduction.mdx
@@ -62,8 +62,4 @@ This distributed approach means no single node can decrypt your data alone, and 
 
 Ready to implement encrypted attestations?
 
-This section of the guide is split up into multiple parts:
-
-- **Basic Encrypted Attestations**: Start with wallet-based access control
-- **Tokenized Access Control**: Use NFTs or tokens to control attestation access
-- **Advanced Conditions**: Combine multiple on-chain and off-chain conditions
+Continue with the [Getting Started](/guides/ts/lit-encrypted-attestations/getting-started) guide to learn how to create encrypted attestations with Lit Protocol.

--- a/docs/pages/guides/ts/lit-encrypted-attestations/introduction.mdx
+++ b/docs/pages/guides/ts/lit-encrypted-attestations/introduction.mdx
@@ -1,0 +1,69 @@
+---
+title: Encrypted Attestation Data with Lit Protocol
+description: Learn how to encrypt and control access to attestation data using Lit Protocol's decentralized key management network
+date: 2025-08-12
+---
+
+# Encrypted Attestation Data with Lit Protocol
+
+## Introduction
+
+Solana attestations are typically stored on-chain for transparency and verifiability. However, many real-world use cases require privacy controls over sensitive attestation data such as: medical records, academic transcripts, personal certifications, and proprietary business information.
+
+Lit Protocol solves this challenge by enabling you to encrypt attestation data while maintaining programmable access control. Instead of storing sensitive data directly on-chain, you can store encrypted data that only authorized parties can decrypt based on conditions you define.
+
+This guide shows you how to combine Solana's attestation service with Lit Protocol's decentralized encryption to create private, yet verifiable attestations.
+
+In this section, we'll cover how to integrate Lit Protocol into the [Basic](/guides/ts/how-to-create-digital-credentials) and [Tokenized](/guides/ts/lit-encrypted-attestations/tokenized-attestation-flow) attestation guides.
+
+## How Lit Protocol Works
+
+Lit Protocol is a decentralized key management network that enables secure encryption without requiring users to manage complex cryptographic keys.
+
+### Access Control Conditions (ACCs)
+
+Rules that define who can decrypt your data, for example:
+
+- Specific wallet addresses
+- NFT or token ownership requirements
+- Time-based conditions
+- Custom logic utilizing on and/or off-chain data
+
+### Identity-Based Encryption
+
+Your data is encrypted using a unique identity derived from your ACCs and a hash of the data you're encrypting. When the Lit nodes generation the decryption key, it's generated on-demand specifically for this identity, meaning a decryption key is only valid to decrypt specific data encrypted with the specific ACCs.
+
+### Threshold Network
+
+Lit is powered by a network of nodes running in Trusted Execution Environments (TEEs) using sealed AMD SEV-SNP hardware that isolates key material from node operators. Your data is encrypted client-side, is never stored on the Lit network, and is not accessible to the Lit nodes.
+
+:::info
+**Learn more about Lit Protocol's architecture and security by visiting the [documentation](https://developer.litprotocol.com) and reading the [whitepaper](https://github.com/LIT-Protocol/whitepaper).**
+:::
+
+## The Encryption Process
+
+1. **Define the ACCs**: Specify who and when your attestation data can be decrypted
+2. **Encrypt the data**: Use Lit's JavaScript SDK to encrypt your attestation content using the Lit network's BLS public key
+3. **Store the encrypted data**: Store the encrypted data on-chain as the Solana attestation
+
+## The Decryption Process
+
+When someone requests to decrypt the attestation data, Lit's network ensures security through a distributed verification process:
+
+1. **Policy verification**: Each Lit node independently verifies that your ACCs are satisfied
+2. **Signature share creation**: If the ACCs are met, each node uses its BLS private key share to sign the identity (a combination of your ACCs and the hash of the data you're encrypting), producing a decryption key share
+3. **Threshold key shares**: Once a threshold (more than two-thirds) of nodes have provided their key shares, the Lit SDK combines them to construct a full decryption key
+4. **Data recovery**: The authorized user uses the reconstructed key to decrypt and access the original attestation data.
+
+This distributed approach means no single node can decrypt your data alone, and decryption only happens when your specified ACCs are completely satisfied.
+
+## Next Steps
+
+Ready to implement encrypted attestations?
+
+This section of the guide is split up into multiple parts:
+
+- **Basic Encrypted Attestations**: Start with wallet-based access control
+- **Tokenized Access Control**: Use NFTs or tokens to control attestation access
+- **Advanced Conditions**: Combine multiple on-chain and off-chain conditions

--- a/docs/pages/guides/ts/lit-encrypted-attestations/tokenized-attestations.mdx
+++ b/docs/pages/guides/ts/lit-encrypted-attestations/tokenized-attestations.mdx
@@ -1,12 +1,12 @@
 ---
-title: Encrypted Basic Attestation Flow
-description: Learn how to encrypt and control access to attestation data using Lit Protocol's decentralized key management network
+title: Encrypted Tokenized Attestations
+description: Learn how to combine tokenized credentials with Lit Protocol encryption for privacy-preserving SPL tokens
 date: 2025-08-12
 ---
 
-# Encrypted Basic Attestation Flow
+# Encrypted Tokenized Attestations
 
-This guide will walk you through integrating Lit encryption into the [Basic Attestation Flow](/guides/ts/how-to-create-digital-credentials) example.
+This guide will walk you through integrating Lit encryption into the [Tokenized Attestations](/guides/ts/tokenized-attestations) example, creating privacy-preserving credentials that are both visible in wallets and protected by programmable access control.
 
 ## Prerequisites
 
@@ -15,16 +15,16 @@ Before starting this guide, you should have:
 - [**Node.js**](https://nodejs.org/en/download) (v22 or later)
 - [**Solana CLI**](https://solana.com/docs/intro/installation) v2.2.x or greater
 - [TypeScript](http://typescriptlang.org/) Experience
-- A working implementation of the [Basic Attestation Flow](/guides/ts/how-to-create-digital-credentials) guide
+- A working implementation of the [Tokenized Attestations](/guides/ts/tokenized-attestations) guide
 - All of the prerequisite Lit helpers functions from the [Getting Started](/guides/ts/lit-encrypted-attestations/getting-started) guide
 
 ## Updating the Existing Implementation
 
-Let's update the existing file, `attestation-demo.ts`, to utilize our Lit helpers functions to encrypt the attestation data:
+Let's update the existing tokenized attestations file to utilize our Lit helpers functions to encrypt the attestation data:
 
 ### Imports and Configuration
 
-Start with the adding necessary imports, the following are all the imports required for this code example:
+Start by adding the necessary imports. The following are all the imports required for this code example:
 
 ```ts
 import type { LitNodeClient } from '@lit-protocol/lit-node-client'
@@ -32,18 +32,21 @@ import {
     getCreateCredentialInstruction,
     getCreateSchemaInstruction,
     serializeAttestationData,
-    getCreateAttestationInstruction,
     fetchSchema,
-    getChangeAuthorizedSignersInstruction,
-    fetchAttestation,
-    deserializeAttestationData,
+    fetchCredential,
     deriveAttestationPda,
     deriveCredentialPda,
     deriveSchemaPda,
-    deriveEventAuthorityAddress,
-    getCloseAttestationInstruction,
+    getTokenizeSchemaInstruction,
+    deriveSchemaMintPda,
+    deriveSasAuthorityAddress,
+    deriveAttestationMintPda,
+    getCreateTokenizedAttestationInstruction,
+    getCloseTokenizedAttestationInstruction,
     SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS,
-    fetchCredential,
+    deriveEventAuthorityAddress,
+    deserializeAttestationData,
+    fetchAttestation,
 } from 'sas-lib'
 import {
     airdropFactory,
@@ -59,7 +62,14 @@ import {
     createTransaction,
     SolanaClient,
 } from 'gill'
-import { estimateComputeUnitLimitFactory } from 'gill/programs'
+import {
+    ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    fetchMint,
+    findAssociatedTokenPda,
+    getMintSize,
+    TOKEN_2022_PROGRAM_ADDRESS,
+    estimateComputeUnitLimitFactory,
+} from 'gill/programs'
 import { ethers } from 'ethers'
 
 import { createSiwsMessage, decryptAttestationData, encryptAttestationData, setupLit, signSiwsMessage } from './lit-helpers'
@@ -72,35 +82,29 @@ Next, update the existing configuration:
 ```ts
 const CONFIG = {
     CLUSTER_OR_RPC: 'devnet',
-    CREDENTIAL_NAME: 'LIT-ENCRYPTED-ATTESTATIONS',
-    SCHEMA_NAME: 'LIT-ENCRYPTED-METADATA',
+    CREDENTIAL_NAME: 'LIT-ENCRYPTED-TOKEN-ATTESTATIONS',
+    SCHEMA_NAME: 'LIT-ENCRYPTED-TOKEN-METADATA',
     SCHEMA_LAYOUT: Buffer.from([12, 12]),
     SCHEMA_FIELDS: ['ciphertext', 'dataToEncryptHash'],
     SCHEMA_VERSION: 1,
-    SCHEMA_DESCRIPTION: 'Schema for Lit Protocol encrypted attestation metadata with access control conditions',
+    SCHEMA_DESCRIPTION: 'Schema for Lit Protocol encrypted tokenized attestation metadata',
     ATTESTATION_DATA: {
         name: 'test-user',
         age: 100,
         country: 'usa',
     },
     ATTESTATION_EXPIRY_DAYS: 365,
+    TOKEN_NAME: 'Encrypted Identity Token',
+    TOKEN_METADATA: 'https://example.com/encrypted-metadata.json',
+    TOKEN_SYMBOL: 'EID',
 }
 ```
 
-Previously, the configuration's `SCHEMA_FIELDS` specified the individual properties of the attestation data. However, now that we'll be encrypting the attestation data, the schema defines the Lit encryption metadata (`ciphertext` and `dataToEncryptHash`) that will be stored on-chain instead, and used for decryption.
-
-For this example, the `SCHEMA_LAYOUT` is set to `Buffer.from([12, 12])` which corresponds to two fields:
-
-- the first `12` represents a String type for the `ciphertext` field,
-- the second `12` represents a String type for the `dataToEncryptHash` field.
+The key difference here is that our `SCHEMA_FIELDS` now define the Lit encryption metadata (`ciphertext` and `dataToEncryptHash`) rather than the actual attestation data fields.
 
 ### Updating `setupWallets`
 
-Next, we're going to make some modifications to the existing `setupWallets` helper function. Instead of generating new keypairs for `authorizedSigner1`, `authorizedSigner2`, and `issuer` every time we run the script, we're going to generate them once and save them as keyfiles in the directory: `key-pairs`.
-
-This is because we need to have a static and predetermined credential PDA that will be hardcoded within our Lit Action that handles the authorization checks and decryption. Hardcoding the credential PDA allows the Lit Action to enforce that only authorized signers for the specific credential are authorized to decrypt the attestation data.
-
-Update the `setupWallets` function to load the keypairs from the keyfiles if they exist, otherwise generate new ones:
+Update the `setupWallets` function to load keypairs from keyfiles:
 
 ```ts
 async function setupWallets(client: SolanaClient) {
@@ -126,14 +130,12 @@ async function setupWallets(client: SolanaClient) {
 }
 ```
 
-This is a key change to the existing Basic Solana Attestation Flow, and without it, we'll be unable to setup our Lit Action to properly authenticate Credential signers when they make requests to Lit to decrypt the attestation data.
+### Updating the Token Verification Function
 
-### Updating the Attestation Verification Function
-
-Next we'll be modifying the existing `verifyAttestation` function to handle retrieving the Lit encryption metadata from the on-chain attestation data, and decrypting it by submitting a signed SIWS message to our custom decryption Lit Action.
+Next we'll be modifying the existing `verifyTokenAttestation` function to handle retrieving the Lit encryption metadata from the on-chain attestation data, and decrypting it by submitting a signed SIWS message to our custom decryption Lit Action.
 
 ```ts
-async function verifyAttestation({
+async function verifyTokenAttestation({
     client,
     schemaPda,
     userAddress,
@@ -152,18 +154,59 @@ async function verifyAttestation({
     try {
         const schema = await fetchSchema(client.rpc, schemaPda)
         if (schema.data.isPaused) {
-            console.log(`    -  Schema is paused`)
+            console.log(`    - Schema is paused`)
             return { isVerified: false, decryptedAttestationData: null }
         }
+
         const [attestationPda] = await deriveAttestationPda({
             credential: schema.data.credential,
             schema: schemaPda,
             nonce: userAddress,
         })
+        const [attestationMint] = await deriveAttestationMintPda({
+            attestation: attestationPda,
+        })
+
+        let mintAccount
+        try {
+            mintAccount = await fetchMint(client.rpc, attestationMint)
+        } catch (error) {
+            // Mint doesn't exist - user doesn't have a tokenized attestation
+            return { isVerified: false, decryptedAttestationData: null }
+        }
+
+        if (!mintAccount) return { isVerified: false, decryptedAttestationData: null }
+        if (mintAccount.data.extensions.__option === 'None') {
+            return { isVerified: false, decryptedAttestationData: null }
+        }
+        const { value: foundExtensions } = mintAccount.data.extensions
+
+        // Verify member of group
+        const [schemaMint] = await deriveSchemaMintPda({
+            schema: schemaPda,
+        })
+        const tokenGroupMember = foundExtensions.find(ext => ext.__kind === 'TokenGroupMember')
+        if (!tokenGroupMember) return { isVerified: false, decryptedAttestationData: null }
+        if (tokenGroupMember.group !== schemaMint) return { isVerified: false, decryptedAttestationData: null }
+
+        // Verify token metadata
+        const tokenMetadata = foundExtensions.find(ext => ext.__kind === 'TokenMetadata')
+        if (!tokenMetadata) return { isVerified: false, decryptedAttestationData: null }
+
+        // Verify attestation PDA matches
+        const attestationInMetadata = tokenMetadata.additionalMetadata.get('attestation')
+        if (attestationInMetadata !== attestationPda) return { isVerified: false, decryptedAttestationData: null }
+
+        // Verify schema PDA matches
+        const schemaInMetadata = tokenMetadata.additionalMetadata.get('schema')
+        if (schemaInMetadata !== schemaPda) return { isVerified: false, decryptedAttestationData: null }
+
+        // Fetch attestation data from chain to get encryption metadata
         const attestation = await fetchAttestation(client.rpc, attestationPda)
         const attestationData = deserializeAttestationData(schema.data, attestation.data.data as Uint8Array) as AttestationEncryptionMetadata
-        console.log(`    - Attestation data:`, attestationData)
+        console.log(`    - Retrieved attestation data from chain`)
 
+        // Decrypt attestation data
         let decryptedAttestationData: string | null = null
         try {
             const siwsMessage = createSiwsMessage({
@@ -181,19 +224,19 @@ async function verifyAttestation({
                 siwsMessageSignature,
             })) as string
         } catch (error) {
-            console.error('There was an error while decrypting the attestation data:', error)
+            console.error('Error while decrypting the attestation data:', error)
             return { isVerified: false, decryptedAttestationData: null }
         }
 
-        const currentTimestamp = BigInt(Math.floor(Date.now() / 1000))
-        return { isVerified: currentTimestamp < attestation.data.expiry, decryptedAttestationData }
+        return { isVerified: true, decryptedAttestationData }
     } catch (error) {
+        console.error('There was an error while verifying the tokenized attestation:', error)
         return { isVerified: false, decryptedAttestationData: null }
     }
 }
 ```
 
-Let's cover the differences between the existing `verifyAttestation` function and the updated one:
+Let's cover the differences between the existing `verifyTokenAttestation` function and the updated one:
 
 - New function parameters:
     - `authorizedSigner`: This parameter is expected to be one of the Credential's Authorized Signer keypairs we loaded from the keyfiles.
@@ -207,7 +250,7 @@ Let's cover the differences between the existing `verifyAttestation` function an
 
 Now that we've setup and covered all the parts of this demo, let's run it!
 
-The following demonstration script follows the same pattern as the Basic Attestation Flow guide, but with some changes that demonstrate how to use the helper functions we created above to encrypt the attestation data.
+The following demonstration script follows the same pattern as the Tokenized Attestation guide, but with some changes that demonstrate how to use the helper functions we created above to encrypt the attestation data.
 
 ### Prerequisites
 
@@ -221,7 +264,7 @@ To do this, we'll add a new script to our `package.json` file:
 }
 ```
 
-And run it:
+Run it:
 
 :::code-group
 
@@ -239,35 +282,17 @@ yarn generate-credential-pda
 
 :::
 
-You should see output similar to the following:
-
-```bash
-> solana-attestation-demo-ts@1.0.0 generate-credential-pda attestation-flow-guides
-> ts-node src/lit/generate-credential-pda.ts
-
-Starting credential PDA generator
-
-1. Getting Issuer keypair...
-issuer keypair does not exist at path: key-pairs/issuer.keypair.json. Generating it...
-Got Issuer keypair with address: EFjEXBpSHL7xXUNZEQf5CKWD7dZHkLfqc1i9tceoqms2
-
-2. Creating Credential...
-Credential PDA: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
-
-Credential PDA generated successfully!
-```
-
-The line: `Credential PDA: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk` is important and what we'll need to hardcode into our decryption Lit Action for the `AUTHORIZED_CREDENTIAL_PDA` constant.
+Copy the generated Credential PDA and update the `AUTHORIZED_CREDENTIAL_PDA` constant in your decryption Lit Action.
 
 ### Step 1: Setup
 
-Now, let's build the main demonstration function that showcases the complete attestation workflow. Add the `main` function to your code--we'll use this to outline for our steps:
+Create the main function:
 
 ```ts
 let _litNodeClient: LitNodeClient | null = null
 
 async function main() {
-    console.log('Starting Solana Attestation Service with Lit Protocol encrypted attestation demo\n')
+    console.log('Starting Solana Attestation Service with Lit Protocol encrypted tokenized attestation demo\n')
 
     const client: SolanaClient = createSolanaClient({ urlOrMoniker: CONFIG.CLUSTER_OR_RPC })
 
@@ -275,29 +300,31 @@ async function main() {
     console.log('1. Setting up wallets and funding payer...')
     const { payer, authorizedSigner1, authorizedSigner2, issuer, testUser } = await setupWallets(client)
 
-    // Step 2: Setting up Lit
+    // Step 2: Setup Lit
 
     // Step 3: Setting up Credential
 
-    // Step 4: Creating Schema
+    // Step 4: Setting up Schema
 
-    // Step 5: Creating Attestation
+    // Step 5: Tokenizing Schema
 
-    // Step 6: Updating Authorized Signers
+    // Step 6: Creating and Encrypting Tokenized Attestation
 
-    // Step 7: Verifying Attestation
+    // Step 7: Verifying Tokenized Attestations
 
-    // Step 8: Closing Attestation
+    // Step 8: Closing Tokenized Attestation
 }
 ```
 
 The current code includes spaces for 8 steps. We've started by creating our client and calling our `setupWallets` function. Let's add the remaining steps next.
 
-### Step 2: Setting up Lit
+### Step 2: Setup Lit
 
 This step is creating our Lit node client, connecting us to the Lit Datil-dev network. Additionally, the Ethereum wallet we'll be using as the payer for the decryption request is generated and returned to us. Add the following code to your `main` function after Step 1:
 
 _Note: remember that while using the Lit Datil-dev network, payment is actually required, but providing a wallet is still required._
+
+Create the file `setup-lit.ts` in our `lit` helpers directory and export the function `setupLit`:
 
 ```ts
 // Step 2: Setup Lit
@@ -306,11 +333,11 @@ const { litNodeClient, litPayerEthersWallet } = await setupLit()
 _litNodeClient = litNodeClient
 ```
 
-### Step 3: Setting up Credential
+### Step 3: Setup Credential
 
 Next we're going to create our Credential account if it doesn't already exist, or fetch the existing one if it does.
 
-Unlike the [Basic Attestation Flow](/guides/ts/how-to-create-digital-credentials.mdx) guide that always creates a new Credential keypair and account every time you run the demo, this demo reuses the Issuer keypair so that we have a static Credential PDA to use in out Lit Action.
+Unlike the [Tokenized Attestation](/guides/ts/tokenized-attestations.mdx) guide that always creates a new Credential keypair and account every time you run the demo, this demo reuses the Issuer keypair so that we have a static Credential PDA to use in out Lit Action.
 
 Add the following code to your `main` function after Step 2:
 
@@ -323,28 +350,25 @@ const [credentialPda] = await deriveCredentialPda({
 })
 
 try {
-    // Check if credential already exists
     const existingCredential = await fetchCredential(client.rpc, credentialPda)
     console.log(`    - Credential already exists: ${credentialPda}`)
     console.log(`    - Authority: ${existingCredential.data.authority}`)
-    console.log(`    - Authorized signers: ${existingCredential.data.authorizedSigners.length}`)
+    console.log(`    - Current authorized signers: ${existingCredential.data.authorizedSigners.length}`)
 } catch (error) {
-    // Credential doesn't exist, create it
     console.log(`    - Creating new credential: ${credentialPda}`)
     const createCredentialInstruction = getCreateCredentialInstruction({
         payer,
         credential: credentialPda,
         authority: issuer,
         name: CONFIG.CREDENTIAL_NAME,
-        signers: [authorizedSigner1.address],
+        signers: [authorizedSigner1.address, authorizedSigner2.address],
     })
-
     await sendAndConfirmInstructions(client, payer, [createCredentialInstruction], 'Credential created')
     console.log(`    - Credential created successfully`)
 }
 ```
 
-### Step 4: Create Schema
+### Step 4: Setup Schema
 
 Next, we need to define our _Schema_ to define the structure of data that can be attested (`ciphertext` and `dataToEncryptHash` in our example).
 
@@ -353,8 +377,8 @@ Just like the Credential PDA, we're going to check if the Schema PDA already exi
 Add the following code to your `main` function after Step 3:
 
 ```ts
-// Step 4: Create Schema
-console.log('\n4.  Creating Schema...')
+// Step 4: Create Schema (if it doesn't exist)
+console.log('\n4. Setting up Schema...')
 const [schemaPda] = await deriveSchemaPda({
     credential: credentialPda,
     name: CONFIG.SCHEMA_NAME,
@@ -362,13 +386,11 @@ const [schemaPda] = await deriveSchemaPda({
 })
 
 try {
-    // Check if schema already exists
     const existingSchema = await fetchSchema(client.rpc, schemaPda)
     console.log(`    - Schema already exists: ${schemaPda}`)
     console.log(`    - Schema name: ${new TextDecoder().decode(existingSchema.data.name)}`)
     console.log(`    - Version: ${existingSchema.data.version}`)
 } catch (error) {
-    // Schema doesn't exist, create it
     console.log(`    - Creating new schema: ${schemaPda}`)
     const createSchemaInstruction = getCreateSchemaInstruction({
         authority: issuer,
@@ -380,121 +402,218 @@ try {
         schema: schemaPda,
         layout: CONFIG.SCHEMA_LAYOUT,
     })
-
     await sendAndConfirmInstructions(client, payer, [createSchemaInstruction], 'Schema created')
     console.log(`    - Schema created successfully`)
 }
 ```
 
-### Step 5: Create Attestation
+### Step 5: Tokenize Schema
 
-Next, we need to issue an actual attestation to a specific user with the defined data and expiration.
+Before utilizing tokenized attestations, you must first tokenize the schema. This step transforms a regular attestation schema into a tokenized schema that serves as a "group" for individual attestation tokens.
 
-Because we're encrypting our attestation data, we need to first encrypt it using Lit Protocol, and then create the attestation using the encryption metadata.
+The code first checks if the schema is already tokenized by trying to fetch an existing schema mint. If it doesn't exist, it creates:
 
-Add the following code to your `main` function after Step 4:
+1. A Program Derived Address for the Token-2022 mint representing this schema
+2. The SAS Authority that will manage all tokenized credentials
+3. Enables the schema mint to act as a group that attestation tokens can join
+4. The actual Token-2022 mint with the calculated space requirements
+
+This infrastructure allows all attestation tokens created from this schema to be members of the same group, enabling wallet integrations to display them as related credentials while maintaining the schema's data structure definitions.
 
 ```ts
-// Step 5: Create and Encrypt Attestation
-console.log('\n5. Creating Attestation...')
+// Step 5: Tokenize Schema (if not already tokenized)
+console.log('\n5. Tokenizing Schema...')
+const [schemaMint] = await deriveSchemaMintPda({
+    schema: schemaPda,
+})
+
+try {
+    const existingMint = await fetchMint(client.rpc, schemaMint)
+    console.log(`    - Schema already tokenized: ${schemaMint}`)
+} catch (error) {
+    console.log(`    - Tokenizing schema...`)
+    const sasPda = await deriveSasAuthorityAddress()
+    const schemaMintAccountSpace = getMintSize([
+        {
+            __kind: 'GroupPointer',
+            authority: sasPda,
+            groupAddress: schemaMint,
+        },
+    ])
+
+    const createTokenizeSchemaInstruction = getTokenizeSchemaInstruction({
+        payer,
+        authority: issuer,
+        credential: credentialPda,
+        schema: schemaPda,
+        mint: schemaMint,
+        sasPda,
+        maxSize: schemaMintAccountSpace,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    })
+
+    await sendAndConfirmInstructions(client, payer, [createTokenizeSchemaInstruction], 'Schema tokenized')
+    console.log(`    - Schema Mint: ${schemaMint}`)
+}
+```
+
+### Step 6: Create Encrypted Tokenized Attestation
+
+This step creates the actual tokenized attestation by combining Lit Protocol encryption with Token-2022 minting. The process involves:
+
+1. Deriving PDAs with getting the attestation PDA and its corresponding mint PDA
+2. Encrypting the attestation with Lit Protocol before storing it on-chain
+3. Calculating token extensions by determining the space needed for multiple Token-2022 extensions (NonTransferable, TokenMetadata, GroupMember, etc.)
+4. Minting the token by creating both the on-chain attestation account with encrypted data and minting a soulbound NFT to the user's wallet
+
+The result is a privacy-preserving credential that appears as a token in wallets but stores only encrypted metadata on-chain, with the actual data only able to be decrypted by the authorized credential signers.
+
+```ts
+// Step 6: Create and Encrypt Tokenized Attestation
+console.log('\n6. Creating Tokenized Attestation...')
 const [attestationPda] = await deriveAttestationPda({
     credential: credentialPda,
     schema: schemaPda,
     nonce: testUser.address,
 })
+const [attestationMint] = await deriveAttestationMintPda({
+    attestation: attestationPda,
+})
 
 const schema = await fetchSchema(client.rpc, schemaPda)
 const expiryTimestamp = Math.floor(Date.now() / 1000) + CONFIG.ATTESTATION_EXPIRY_DAYS * 24 * 60 * 60
+const sasPda = await deriveSasAuthorityAddress()
+const [recipientTokenAccount] = await findAssociatedTokenPda({
+    mint: attestationMint,
+    owner: testUser.address,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+})
 
+// Encrypt the attestation data
 const attestationEncryptionMetadata = await encryptAttestationData({
     attestationData: new TextEncoder().encode(JSON.stringify(CONFIG.ATTESTATION_DATA)),
     litNodeClient,
 })
 
-const createAttestationInstruction = getCreateAttestationInstruction({
+const attestationMintAccountSpace = getMintSize([
+    {
+        __kind: 'GroupMemberPointer',
+        authority: sasPda,
+        memberAddress: attestationMint,
+    },
+    { __kind: 'NonTransferable' },
+    {
+        __kind: 'MetadataPointer',
+        authority: sasPda,
+        metadataAddress: attestationMint,
+    },
+    { __kind: 'PermanentDelegate', delegate: sasPda },
+    { __kind: 'MintCloseAuthority', closeAuthority: sasPda },
+    {
+        __kind: 'TokenMetadata',
+        updateAuthority: sasPda,
+        mint: attestationMint,
+        name: CONFIG.TOKEN_NAME,
+        symbol: CONFIG.TOKEN_SYMBOL,
+        uri: CONFIG.TOKEN_METADATA,
+        additionalMetadata: new Map([
+            ['attestation', attestationPda],
+            ['schema', schemaPda],
+        ]),
+    },
+    {
+        __kind: 'TokenGroupMember',
+        group: schemaMint,
+        mint: attestationMint,
+        memberNumber: 1,
+    },
+])
+
+const createTokenizedAttestationInstruction = await getCreateTokenizedAttestationInstruction({
     payer,
     authority: authorizedSigner1,
     credential: credentialPda,
     schema: schemaPda,
     attestation: attestationPda,
+    schemaMint: schemaMint,
+    attestationMint,
+    sasPda,
+    recipient: testUser.address,
     nonce: testUser.address,
     expiry: expiryTimestamp,
     data: serializeAttestationData(schema.data, {
         ...attestationEncryptionMetadata,
     }),
+    name: CONFIG.TOKEN_NAME,
+    uri: CONFIG.TOKEN_METADATA,
+    symbol: CONFIG.TOKEN_SYMBOL,
+    mintAccountSpace: attestationMintAccountSpace,
+    recipientTokenAccount: recipientTokenAccount,
+    associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
 })
 
-await sendAndConfirmInstructions(client, payer, [createAttestationInstruction], 'Attestation created')
+await sendAndConfirmInstructions(client, payer, [createTokenizedAttestationInstruction], 'Tokenized attestation created')
 console.log(`    - Attestation PDA: ${attestationPda}`)
+console.log(`    - Attestation Mint: ${attestationMint}`)
 ```
 
-### Step 6: Update Authorized Signers
+### Step 7: Verify Attestations
 
-Next, let's add `authorizedSigner2` as an authorized signer to our credential to demonstrate how to manage who can issue attestations for the credential.
+This step demonstrates the comprehensive verification process for encrypted tokenized attestations. The verification involves:
 
-Add the following code to your `main` function after Step 5:
+1. Checks that the token exists and has proper Token-2022 extensions
+2. Verifies the token is a member of the correct schema group
+3. Validates that token metadata references the correct attestation and schema PDAs
+4. Uses Lit Protocol to decrypt the attestation data, which only succeeds if the signer is authorized
+5. Tests with unauthorized signers to confirm the access control system works correctly
 
-```ts
-// Step 6: Update Authorized Signers
-console.log('\n6. Updating Authorized Signers...')
-const changeAuthSignersInstruction = getChangeAuthorizedSignersInstruction({
-    payer,
-    authority: issuer,
-    credential: credentialPda,
-    signers: [authorizedSigner1.address, authorizedSigner2.address],
-})
-
-await sendAndConfirmInstructions(client, payer, [changeAuthSignersInstruction], 'Authorized signers updated')
-```
-
-### Step 7: Verify Attestation
-
-Let's run a verification check to show how you might check if users have valid attestations, testing both attested and non-attested users. Normally, you might run something like this on your backend when a user signs into your platform.
-
-Add the following code to your `main` function after Step 6:
+The verification process combines on-chain token verification with Lit's decentralized access control, ensuring both the integrity of the tokenized credential and the privacy of its data.
 
 ```ts
-// Step 7: Verify Attestation
-console.log('\n7. Verifying Attestations...')
+// Step 7: Verify Tokenized Attestations
+console.log('\n7. Verifying Tokenized Attestations...')
 
-const isUserVerified = await verifyAttestation({
+const verification = await verifyTokenAttestation({
     client,
     schemaPda,
     userAddress: testUser.address,
-    authorizedSigner: authorizedSigner1, // Use one of the authorized signers
+    authorizedSigner: authorizedSigner1,
     litDecryptionParams: {
         litNodeClient,
         litPayerEthersWallet,
     },
 })
-console.log(`    - Test User is ${isUserVerified.isVerified ? 'verified' : 'not verified'}`)
-if (isUserVerified.decryptedAttestationData) {
-    console.log(`    - Decrypted Attestation Data: ${isUserVerified.decryptedAttestationData}`)
+
+console.log(`    - Test User is ${verification.isVerified ? 'verified' : 'not verified'}`)
+console.log(`    - Test User's token is ${verification.isVerified ? 'valid' : 'invalid'}`)
+if (verification.decryptedAttestationData) {
+    console.log(`    - Decrypted Attestation Data: ${verification.decryptedAttestationData}`)
 }
 
 const randomUser = await generateKeyPairSigner()
-const isRandomVerified = await verifyAttestation({
+const randomVerification = await verifyTokenAttestation({
     client,
     schemaPda,
     userAddress: randomUser.address,
-    authorizedSigner: authorizedSigner2, // Use the other authorized signer
+    authorizedSigner: authorizedSigner2,
     litDecryptionParams: {
         litNodeClient,
         litPayerEthersWallet,
     },
 })
-console.log(`    - Random User is ${isRandomVerified.isVerified ? 'verified' : 'not verified'}`)
+console.log(`    - Random User is ${randomVerification.isVerified ? 'verified' : 'not verified'}`)
 
 // Test with unauthorized signer (should fail)
 console.log('\n    Testing with unauthorized signer (should fail)...')
 const unauthorizedSigner = await generateKeyPairSigner()
 console.log(`    - Unauthorized signer address: ${unauthorizedSigner.address}`)
 
-const unauthorizedResult = await verifyAttestation({
+const unauthorizedResult = await verifyTokenAttestation({
     client,
     schemaPda,
     userAddress: testUser.address,
-    authorizedSigner: unauthorizedSigner, // This signer is NOT in the credential
+    authorizedSigner: unauthorizedSigner,
     litDecryptionParams: {
         litNodeClient,
         litPayerEthersWallet,
@@ -508,25 +627,36 @@ if (unauthorizedResult.isVerified) {
 }
 ```
 
-### Step 8: Close Attestation
+### Step 8: Close Tokenized Attestation
 
-Finally, let's revoke an attestation from a user, and return the summary data for pretty printing.
+This final step demonstrates credential revocation by permanently removing both the on-chain attestation data and the tokenized representation. The process involves:
 
-Add the following code to your `main` function after Step 7:
+1. Gets the event authority address required for emitting close events in the SAS program.
+2. Uses `getCloseTokenizedAttestationInstruction` to create the close instruction with proper Token-2022 program integration.
+3. Completely removes the token from the recipient's wallet by burning and closing the mint operations.
+4. Closes the attestation account, recovering the rent and removing the encrypted data from the blockchain.
+
+This step showcases how credentials can be revoked in a way that's both visible (token disappears from wallet) and permanent (encrypted data is removed from chain), providing a complete lifecycle management solution for tokenized credentials.
 
 ```ts
-console.log('\n8. Closing Attestation...')
-
+// Step 8: Close Tokenized Attestation
+console.log('\n8. Closing Tokenized Attestation...')
 const eventAuthority = await deriveEventAuthorityAddress()
-const closeAttestationInstruction = getCloseAttestationInstruction({
+
+const closeTokenizedAttestationInstruction = getCloseTokenizedAttestationInstruction({
     payer,
-    attestation: attestationPda,
     authority: authorizedSigner1,
     credential: credentialPda,
+    attestation: attestationPda,
     eventAuthority,
     attestationProgram: SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS,
+    attestationMint,
+    sasPda,
+    attestationTokenAccount: recipientTokenAccount,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
 })
-await sendAndConfirmInstructions(client, payer, [closeAttestationInstruction], 'Closed attestation')
+
+await sendAndConfirmInstructions(client, payer, [closeTokenizedAttestationInstruction], 'Tokenized Attestation closed')
 
 // Return summary data for pretty printing
 return {
@@ -534,10 +664,12 @@ return {
         credentialPda,
         schemaPda,
         attestationPda,
+        schemaMint,
+        attestationMint,
         testUserAddress: testUser.address,
     },
-    verification: isUserVerified,
-    randomVerification: isRandomVerified,
+    verification,
+    randomVerification,
     unauthorizedResult,
     config: CONFIG,
     attestationEncryptionMetadata,
@@ -561,11 +693,14 @@ main()
         console.log(`   Network: ${results.config.CLUSTER_OR_RPC}`)
         console.log(`   Organization: ${results.config.CREDENTIAL_NAME}`)
         console.log(`   Schema: ${results.config.SCHEMA_NAME} (v${results.config.SCHEMA_VERSION})`)
+        console.log(`   Token: ${results.config.TOKEN_NAME} (${results.config.TOKEN_SYMBOL})`)
 
         console.log('\n🔑 CREATED ACCOUNTS:')
         console.log(`   Credential PDA:    ${results.addresses.credentialPda}`)
         console.log(`   Schema PDA:        ${results.addresses.schemaPda}`)
+        console.log(`   Schema Mint:       ${results.addresses.schemaMint}`)
         console.log(`   Attestation PDA:   ${results.addresses.attestationPda}`)
+        console.log(`   Attestation Mint:  ${results.addresses.attestationMint}`)
         console.log(`   Test User:         ${results.addresses.testUserAddress}`)
 
         console.log('\n🧪 VERIFICATION TEST RESULTS:')
@@ -595,7 +730,7 @@ main()
         if (allTestsPassed) {
             console.log('   ✅ ALL TESTS PASSED! Demo completed successfully.')
         } else {
-            console.log('   ❌ Some tests failed. Please review the results above.')
+            console.log('   ❌  Some tests failed. Please review the results above.')
         }
 
         console.log('\n' + '='.repeat(80))
@@ -611,19 +746,19 @@ main()
 
 ## Running the Demonstration
 
-To test your attestation workflow, run the script in your project terminal:
+To test your encrypted tokenized attestation workflow:
 
 :::note
 In order to run the demonstration using the following command, make sure you're `package.json` contains the following:
 
 ```json
 "scripts": {
-  "start": "ts-node attestation-demo.ts",
+  "start": "ts-node tokenized-attestation-demo.ts",
   "build": "tsc"
 }
 ```
 
-If you've copied the existing `attestation-demo.ts` file and renamed it for this encryption code example, make sure you use the new file name here in the `start` script.
+If you've copied the existing `tokenized-attestation-demo.ts` file and renamed it for this encryption code example, make sure you use the new file name here in the `start` script.
 
 :::
 
@@ -643,70 +778,64 @@ yarn start
 
 :::
 
-Here's what you should expect to see in the output:
+Expected output:
 
 ```bash
 lit-js-sdk:constants:errors deprecated LitErrorKind is deprecated and will be removed in a future version. Use LIT_ERROR_KIND instead. node:internal/modules/cjs/loader:1692:14
-Starting Solana Attestation Service with Lit Protocol encrypted attestation demo
+Starting Solana Attestation Service with Lit Protocol encrypted tokenized attestation demo
 
 1. Setting up wallets and funding payer...
-authorized-signer-1 keypair does not exist at path: key-pairs/authorized-signer-1.keypair.json. Generating it...
 Got Authorized Signer 1 keypair with address: 8XMEduQLuEw4LHGD6a66LeH1TKJsa3rpghGnM1mjbHCN
-authorized-signer-2 keypair does not exist at path: key-pairs/authorized-signer-2.keypair.json. Generating it...
 Got Authorized Signer 2 keypair with address: 8BDVzsSvqFFMDpcqcueTBVnPu33aqP72XJq3QUfGAeho
 Got Issuer keypair with address: EFjEXBpSHL7xXUNZEQf5CKWD7dZHkLfqc1i9tceoqms2
-    - Airdrop completed: 5oZPNTNhkXZDvEeKFDrwhwym49QCn8pvPTfFfZHjhMA9CR8Me29fXuFx4cRWFRwnTM37j4sCEh7DhUaapaygQ72r
+    - Airdrop completed: 2PknYz2Pzf9VMFGRW4ZLv5E76yWia6YDMksvjKhZTN7M9xcvzZ85UYBZ6RjeyTk6gR2pnd2ijaWR592wJ2btT8Hd
 2. Setting up Lit...
 lit-js-sdk:constants:constants deprecated LogLevel is deprecated and will be removed in a future version. Use LOG_LEVEL instead. node_modules/.pnpm/@lit-protocol+core@7.2.1_typescript@5.8.3/node_modules/@lit-protocol/core/src/lib/lit-core.js:453:119
 
 3. Setting up Credential...
-    - Creating new credential: Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
-    - Credential created - Signature: 2LtJedSKv7bKcoSLKLQxt2Woio8r4cxkXdcvxmTAEY1B8Y5TRHuddtnkQwQm6Gu7WLLnJsP9ZL5XCvBL67KAW8SH
-    - Credential created successfully
+    - Credential already exists: 4Uk8L52m58FEhU9ECqwzh7KtL1698PM82xPpLnwhPmr7
+    - Authority: EFjEXBpSHL7xXUNZEQf5CKWD7dZHkLfqc1i9tceoqms2
+    - Current authorized signers: 2
 
-4.  Creating Schema...
-    - Creating new schema: 9Zhbp3ybaZGnPQH6LHuC6fE51qu33g1byan9X34XGcqa
-    - Schema created - Signature: 4Uu4oSh6dFQg81ryXQsYiPwWgGSqg7rNpRSogAo4g3EVmzL8Z6h8qABviPQVEoqUENRJgkfnbgm7ttrLTPb1GhnR
-    - Schema created successfully
+4. Setting up Schema...
+    - Schema already exists: E7Riv3KhCcU33pvonkXU1A7CojDpvJGzrv7HwaNNyBwi
+    - Schema name: LIT-ENCRYPTED-TOKEN-METADATA
+    - Version: 1
 
-5. Creating Attestation...
+5. Tokenizing Schema...
+    - Schema already tokenized: J9vbrzrXVhfKYN69ADYFbNjZYNem5oQTqrnBTq76VYLn
+
+6. Creating Tokenized Attestation...
 using deprecated parameters for `initSync()`; pass a single object instead
-    - Attestation created - Signature: 3KBcnS3FnH1ACn1hPhEhGB9aMDLRvr31fC5fizMEC1Qiz38WEGEXgWqMhsyqEJabYoHWe5scSaxeMcvtBTdXnh7b
-    - Attestation PDA: 5Baypg1tZ6M1wmBKw56b5YZ6RV7AyJtrsyD5kVSZ9q3C
+    - Tokenized attestation created: 3AEAjSemmBoZteZm5czdokbzc1yHtJYBQGqGrimsZbq92TYRiRAheuqaSaWoAukRkqNAtFZXhiRgFXjeyjkspUL
+    - Attestation PDA: Ad4yLyhW9T9Q3VaCkgcnsARDwbprWxBK7YDJyyshjEoF
+    - Attestation Mint: 34JxLEer3synJnsmKmcZTbycDCk7AdXQAJQ3WqG2LKVa
 
-6. Updating Authorized Signers...
-    - Authorized signers updated - Signature: 5zCcr9A3Z6ag4pCNHi4BwaSDdvqjZStJWBu43RgidvYYSLSwsf5mPbRHjNo41caVfAdHEgWgJ52QFRuWjopZn8KK
-
-7. Verifying Attestations...
-    - Attestation data: {
-  ciphertext: 'mBWDUTwA+LHxmhAbFGO3H+wc24rshZZgynWblL6IFsUxvbuipA2goo5Ps66i/4sH5ecEb/G67AE/1KvxyvhvUZCpagAWMYZvR6gg7q/5tVQvfEV6mL6XD9e9U0u00izx6ILiMUVJU/tnt2FNVNU6aTQC8IS4PSPGx6KIE+iSC68C',
-  dataToEncryptHash: '4efa888818ad5ba81b0e459037eb8c62a3f0bdf401de5372e21d8aa132a0a808'
-}
+7. Verifying Tokenized Attestations...
+    - Retrieved attestation data from chain
 Storage key "lit-session-key" is missing. Not a problem. Continue...
 Storage key "lit-wallet-sig" is missing. Not a problem. Continue...
 Unable to store walletSig in local storage. Not a problem. Continue...
     - Test User is verified
+    - Test User's token is valid
     - Decrypted Attestation Data: {"name":"test-user","age":100,"country":"usa"}
     - Random User is not verified
 
     Testing with unauthorized signer (should fail)...
-    - Unauthorized signer address: EHG46v4pFgRwtrfteCds1sApEvSJWnnN7iFkUGcMERAF
-    - Attestation data: {
-  ciphertext: 'mBWDUTwA+LHxmhAbFGO3H+wc24rshZZgynWblL6IFsUxvbuipA2goo5Ps66i/4sH5ecEb/G67AE/1KvxyvhvUZCpagAWMYZvR6gg7q/5tVQvfEV6mL6XD9e9U0u00izx6ILiMUVJU/tnt2FNVNU6aTQC8IS4PSPGx6KIE+iSC68C',
-  dataToEncryptHash: '4efa888818ad5ba81b0e459037eb8c62a3f0bdf401de5372e21d8aa132a0a808'
-}
+    - Unauthorized signer address: 2Cf17RYkNad2FP8WPmsiQbvQnvrprsppkaFmHK7PEzYU
+    - Retrieved attestation data from chain
 Storage key "lit-session-key" is missing. Not a problem. Continue...
 Storage key "lit-wallet-sig" is missing. Not a problem. Continue...
 Unable to store walletSig in local storage. Not a problem. Continue...
-There was an error while decrypting the attestation data: Error: An unexpected error occurred while decrypting the attestation data: Failed to decrypt attestation data: {"success":false,"message":"Signer is not authorized to decrypt","authorizedSigners":["8XMEduQLuEw4LHGD6a66LeH1TKJsa3rpghGnM1mjbHCN","8BDVzsSvqFFMDpcqcueTBVnPu33aqP72XJq3QUfGAeho"],"requestingSigner":"EHG46v4pFgRwtrfteCds1sApEvSJWnnN7iFkUGcMERAF"}
+Error while decrypting the attestation data: Error: An unexpected error occurred while decrypting the attestation data: Failed to decrypt attestation data: {"success":false,"message":"Signer is not authorized to decrypt","authorizedSigners":["8XMEduQLuEw4LHGD6a66LeH1TKJsa3rpghGnM1mjbHCN","8BDVzsSvqFFMDpcqcueTBVnPu33aqP72XJq3QUfGAeho"],"requestingSigner":"2Cf17RYkNad2FP8WPmsiQbvQnvrprsppkaFmHK7PEzYU"}
     at decryptAttestationData (lit/decrypt-attestation-data.ts:80:15)
     at processTicksAndRejections (node:internal/process/task_queues:105:5)
-    at async verifyAttestation (attestation-demo.ts:149:40)
-    at async main (attestation-demo.ts:334:32)
+    at async verifyTokenAttestation (decrypt-attestation-data.ts:201:40)
+    at async main (decrypt-attestation-data.ts:456:32)
     - ✅ Unauthorized signer is not verified
 
-7. Closing Attestation...
-    - Closed attestation - Signature: b6NFkqmsLTeCeLoWJocx2n152vx5TcLehA9R4i3piZefeGroBzv91Lesdwdsn61N1MnF4L7ETPv7z9f2TUmDXwK
+8. Closing Tokenized Attestation...
+    - Tokenized Attestation closed: 3TVGek5VUEmsjygruVYRyJRBuAsf7uYmFnxw5BhyjkDApL7DVzrMEcG232sS6X7hRosy74vnKj4KNFZYXTQCuy36
 
 ================================================================================
 SOLANA ATTESTATION SERVICE WITH LIT PROTOCOL ENCRYPTED ATTESTATION DEMO
@@ -714,19 +843,22 @@ SOLANA ATTESTATION SERVICE WITH LIT PROTOCOL ENCRYPTED ATTESTATION DEMO
 
 📋 DEMO CONFIGURATION:
    Network: devnet
-   Organization: LIT-ENCRYPTED-ATTESTATIONS
-   Schema: LIT-ENCRYPTED-METADATA (v1)
+   Organization: LIT-ENCRYPTED-TOKEN-ATTESTATIONS
+   Schema: LIT-ENCRYPTED-TOKEN-METADATA (v1)
+   Token: Encrypted Identity Token (EID)
 
 🔑 CREATED ACCOUNTS:
-   Credential PDA:    Cuk2RuHYCMv1QcpB7bGqdXPafJs5BG2JNfbJqbyVkyRk
-   Schema PDA:        9Zhbp3ybaZGnPQH6LHuC6fE51qu33g1byan9X34XGcqa
-   Attestation PDA:   5Baypg1tZ6M1wmBKw56b5YZ6RV7AyJtrsyD5kVSZ9q3C
-   Test User:         FgHoHpy589aV5y6dKymwZ1okJ8nL6p8x4eqotf7rMMfj
+   Credential PDA:    4Uk8L52m58FEhU9ECqwzh7KtL1698PM82xPpLnwhPmr7
+   Schema PDA:        E7Riv3KhCcU33pvonkXU1A7CojDpvJGzrv7HwaNNyBwi
+   Schema Mint:       J9vbrzrXVhfKYN69ADYFbNjZYNem5oQTqrnBTq76VYLn
+   Attestation PDA:   Ad4yLyhW9T9Q3VaCkgcnsARDwbprWxBK7YDJyyshjEoF
+   Attestation Mint:  34JxLEer3synJnsmKmcZTbycDCk7AdXQAJQ3WqG2LKVa
+   Test User:         BfLgYU4Zf9N1infWDoxMP83pxSKywmAaSiA8ghKNDPDU
 
 🧪 VERIFICATION TEST RESULTS:
    Test User Verification:     ✅ PASSED
    Encrypted Metadata:
-     - Ciphertext: mBWDUTwA+LHxmhAbFGO3H+wc24rshZZgynWblL6IFsUxvbuipA...
+     - Ciphertext: oc+2f+GJOXIr5R6XAC+aDgIJFvK+GbuOn9wa8qsBEzbvMChcJS...
      - Data Hash: 4efa888818ad5ba81b0e459037eb8c62a3f0bdf401de5372e21d8aa132a0a808
    Decrypted Attestation Data: {"name":"test-user","age":100,"country":"usa"}
    Random User Verification:   ✅ PASSED (correctly rejected)
@@ -742,25 +874,24 @@ If you see `✅ ALL TESTS PASSED! Demo completed successfully.`, you've successf
 
 ## Wrap Up
 
-Congratulations! You've successfully implemented a complete Solana Attestation Service system using Lit Protocol to encrypt the attestation data. You now have a working demonstration that shows how to:
+Congratulations! You've successfully implemented a complete Tokenized Solana Attestation Service system using Lit Protocol to encrypt the attestation data. You now have a working demonstration that shows how to:
 
 - **Create credentials** that represent issuing authorities
 - **Define schemas** for encrypted attestation metadata (`ciphertext` and `dataToEncryptHash`)
+- **Tokenize schemas** to create credential groups for wallet visibility
 - **Encrypt attestation data using Lit Protocol** with custom access control conditions
-- **Issue encrypted attestations** to specific users, storing only Lit encryption metadata on-chain
+- **Issue encrypted tokenized attestations** as SPL tokens, storing only Lit encryption metadata on-chain
 - **Manage authorized signers** for enhanced security and dynamic access control
 - **Verify and decrypt attestations** programmatically, ensuring only authorized signers can access the underlying data
-- **Close (revoke) attestations** as needed
+- **Close (revoke) tokenized attestations** by burning tokens and removing encrypted data
 
 The Solana Attestation Service (SAS) provides a powerful foundation for building trust and identity systems on Solana. Whether you're creating compliance systems, financial credentials, professional certifications, or gaming achievements, SAS gives you the tools to issue and verify claims in a decentralized, transparent way.
-
-**Want to learn more?** Check out our [Guide: Encrypted Tokenized Attestations with Lit Protocol](/guides/ts/lit-encrypted-attestations/tokenized-attestation-flow).
 
 ## Additional Resources
 
 - Need help? Ask questions the [Solana Stack Exchange](https://solana.stackexchange.com/) with a `SAS` tag.
 - [**SAS Source Code**](https://github.com/solana-foundation/solana-attestation-service)
-- [**Complete Code Example**](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript/attestation-flow-guides/src/lit/sas-standard-lit-demo.ts)
+- [**Complete Code Example**](https://github.com/solana-foundation/solana-attestation-service/tree/master/examples/typescript/attestation-flow-guides/src/lit/sas-tokenized-lit-demo.ts)
 - [**Solana Developer Resources**](https://solana.com/developers)
 - [**Lit Protocol Documentation**](https://developer.litprotocol.com/)
 - [**Lit Protocol Builders Telegram Group**](https://t.me/+aa73FAF9Vp82ZjJh)

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -132,12 +132,20 @@ export default defineConfig({
                             collapsed: false,
                             items: [
                                 {
-                                    text: "Basic Attestation Flow",
+                                    text: "Introduction",
+                                    link: "/guides/ts/lit-encrypted-attestations/introduction"
+                                },
+                                {
+                                    text: "Getting Started",
+                                    link: "/guides/ts/lit-encrypted-attestations/getting-started"
+                                },
+                                {
+                                    text: "Encrypted Basic Attestation Flow",
                                     link: "/guides/ts/lit-encrypted-attestations/basic-attestation-flow"
                                 },
                                 {
-                                    text: "Tokenized Attestations",
-                                    link: "/guides/ts/lit-encrypted-attestations/tokenized-attestation-flow"
+                                    text: "Encrypted Tokenized Attestation",
+                                    link: "/guides/ts/lit-encrypted-attestations/tokenized-attestation"
                                 }
                             ]
                         }

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -126,6 +126,20 @@ export default defineConfig({
                         {
                             text: "Tokenized Attestations",
                             link: "/guides/ts/tokenized-attestations"
+                        },
+                        {
+                            text: "Encrypted Attestation Data",
+                            collapsed: false,
+                            items: [
+                                {
+                                    text: "Basic Attestation Flow",
+                                    link: "/guides/ts/lit-encrypted-attestations/basic-attestation-flow"
+                                },
+                                {
+                                    text: "Tokenized Attestations",
+                                    link: "/guides/ts/lit-encrypted-attestations/tokenized-attestation-flow"
+                                }
+                            ]
                         }
                     ]
                 },

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -145,7 +145,7 @@ export default defineConfig({
                                 },
                                 {
                                     text: "Encrypted Tokenized Attestation",
-                                    link: "/guides/ts/lit-encrypted-attestations/tokenized-attestation"
+                                    link: "/guides/ts/lit-encrypted-attestations/tokenized-attestations"
                                 }
                             ]
                         }


### PR DESCRIPTION
Corresponding [PR](https://github.com/solana-foundation/solana-attestation-service/pull/94) for the code examples these guides are based off of

Creates 4 new pages under the `Encrypted Attestation Data` subsection:

<img width="296" height="274" alt="image" src="https://github.com/user-attachments/assets/cc209efe-4a6a-49f5-9928-41a2af22ce97" />
